### PR TITLE
add load_dotenv in chapter8

### DIFF
--- a/docs/chapter8/第八章 记忆与检索.md
+++ b/docs/chapter8/第八章 记忆与检索.md
@@ -218,6 +218,9 @@ EMBED_BASE_URL=
 
 ```python
 # 配置好同级文件夹下.env中的大模型API
+from dotenv import load_dotenv
+load_dotenv()
+
 from hello_agents import SimpleAgent, HelloAgentsLLM, ToolRegistry
 from hello_agents.tools import MemoryTool, RAGTool
 


### PR DESCRIPTION
We better load our .env before we load the modules from hello-agents
If we load like this
```
    from hello_agents import SimpleAgent, HelloAgentsLLM, ToolRegistry
    from hello_agents.tools import MemoryTool, RAGTool
    load_dotenv()
```
We will encounter a problem:
If our virtual python environment like this 
```
~/Desktop/OpenManus/.venv/lib/python3.12/site-packages/hello_agents
```
But our test file like this
```
~/Desktop/hello-agents/chapter8/test.py
```
when we load config in this file
```
~/Desktop/OpenManus/.venv/lib/python3.12/site-packages/hello_agents/core/database_config.py
```
 we can't get the properties we have set in ***~/Desktop/hello-agents/chapter8/.env***
The singleton pattern for creating Qdrant instances within QdrantConnectionManager will fail, resulting in an error.    