### PR TITLE
fix:修改4.2.3prompt占位符问题

### DIFF
--- a/docs/chapter4/Chapter4-Building-Classic-Agent-Paradigms.md
+++ b/docs/chapter4/Chapter4-Building-Classic-Agent-Paradigms.md
@@ -364,7 +364,7 @@ Please respond strictly in the following format:
 
 Thought: Your thinking process, used to analyze problems, decompose tasks, and plan the next action.
 Action: The action you decide to take, must be in one of the following formats:
-- `{tool_name}[{tool_input}]`: Call an available tool.
+- {{tool_name}}[{{tool_input}}]`: Call an available tool.
 - `Finish[final answer]`: When you believe you have obtained the final answer.
 - When you have collected enough information to answer the user's final question, you must use `finish(answer="...")` after the Action: field to output the final answer.
 

--- a/docs/chapter4/第四章 智能体经典范式构建.md
+++ b/docs/chapter4/第四章 智能体经典范式构建.md
@@ -364,7 +364,7 @@ REACT_PROMPT_TEMPLATE = """
 
 Thought: 你的思考过程，用于分析问题、拆解任务和规划下一步行动。
 Action: 你决定采取的行动，必须是以下格式之一:
-- `{tool_name}[{tool_input}]`:调用一个可用工具。
+- `{{tool_name}}[{{tool_input}}]`:调用一个可用工具。
 - `Finish[最终答案]`:当你认为已经获得最终答案时。
 - 当你收集到足够的信息，能够回答用户的最终问题时，你必须在Action:字段后使用 finish(answer="...") 来输出最终答案。
 


### PR DESCRIPTION
在code目录下，第四章ReAct.py中的prompt是使用 **_{{}}双花括号_** 来包裹的tool_name和tool_inputs，但是在docs目录下4.2.3小节中，提供的prompt是使用 **_{}单花括号_** 来包裹的tool_name和tool_inputs，这会导致在后续prompt初始化时，报错要求提供tool_name和tool_inputs. #116 