### PR TITLE
docs(chapter8): 修正文档中错误的参数语法格式

### DIFF
--- a/docs/chapter8/第八章 记忆与检索.md
+++ b/docs/chapter8/第八章 记忆与检索.md
@@ -388,7 +388,7 @@ def execute(self, action: str, **kwargs) -> str:
     # ... 其他操作
 ````
 
-这种统一的`execute`接口设计简化了Agent的调用方式，通过`action`参数指定具体操作，使用`<strong>kwargs`允许每个操作有不同的参数需求。在这里我们会将比较重要的几个操作罗列出来：
+这种统一的`execute`接口设计简化了Agent的调用方式，通过`action`参数指定具体操作，使用`**kwargs`允许每个操作有不同的参数需求。在这里我们会将比较重要的几个操作罗列出来：
 
 （1）操作1：add
 
@@ -402,7 +402,7 @@ def _add_memory(
     importance: float = 0.5,
     file_path: str = None,
     modality: str = None,
-    </strong>metadata
+    **metadata
 ) -> str:
     """添加记忆"""
     try:


### PR DESCRIPTION
将文档中错误的`<strong>kwargs`和`</strong>metadata`修正为正确的`**kwargs`和`**metadata`语法格式