### PR TITLE
docs(chapter7): 修正文档中的prompt模板

### DIFF
--- a/docs/chapter7/第七章 构建你的Agent框架.md
+++ b/docs/chapter7/第七章 构建你的Agent框架.md
@@ -1234,7 +1234,7 @@ print(f"对话历史: {len(agent.get_history())} 条消息")
 
 在最后可以补充一款新的提示词，可以尝试实现`custom_prompt`载入自定义提示词。
 
-```python
+````python
 # 创建专门用于数学问题的自定义提示词
 math_prompts = {
     "planner": """
@@ -1269,7 +1269,7 @@ math_agent = MyPlanAndSolveAgent(
 # 测试数学问题
 math_result = math_agent.run(question)
 print(f"数学专用Agent结果: {math_result}")
-```
+````
 
 如表7.2所示，通过这种框架化的重构，我们不仅保持了第四章中各种Agent范式的核心功能，还大幅提升了代码的组织性、可维护性和扩展性。所有Agent现在都共享统一的基础架构，同时保持了各自的特色和优势。
 


### PR DESCRIPTION
在
````
math_prompts = {
    "planner": """
你是数学问题规划专家。请将数学问题分解为计算步骤:

问题: {question}

输出格式:
python
["计算步骤1", "计算步骤2", "求总和"]

""",
````
里面添加前后```，改成：
````
math_prompts = {
    "planner": """
你是数学问题规划专家。请将数学问题分解为计算步骤:

问题: {question}

输出格式:
```python
["计算步骤1", "计算步骤2", "求总和"]
```
""",
````