### PR TITLE
修复了关于CAMEL智能体开发框架的演示原代码中忘记写关于创建API模型客户端导致代码无法跑通的问题。

### DIFF
--- a/code/chapter6/CAMEL/DigitalBookWriting.py
+++ b/code/chapter6/CAMEL/DigitalBookWriting.py
@@ -1,6 +1,23 @@
 from colorama import Fore
 from camel.societies import RolePlaying
 from camel.utils import print_text_animated
+from camel.models import ModelFactory
+from camel.types import ModelPlatformType
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+LLM_API_KEY = os.getenv("LLM_API_KEY")
+LLM_BASE_URL = os.getenv("LLM_BASE_URL")
+LLM_MODEL = os.getenv("LLM_MODEL")
+
+#创建模型,在这里以Qwen为例,调用的百炼大模型平台API
+model = ModelFactory.create(
+    model_platform=ModelPlatformType.QWEN,
+    model_type=LLM_MODEL,
+    url=LLM_BASE_URL,
+    api_key=LLM_API_KEY
+)
 
 # 定义协作任务
 task_prompt = """
@@ -19,7 +36,8 @@ print(Fore.YELLOW + f"协作任务:\n{task_prompt}\n")
 role_play_session = RolePlaying(
     assistant_role_name="心理学家", 
     user_role_name="作家", 
-    task_prompt=task_prompt
+    task_prompt=task_prompt,
+    model=model
 )
 
 print(Fore.CYAN + f"具体任务描述:\n{role_play_session.task_prompt}\n")


### PR DESCRIPTION
# 问题：

在实践中运行代码时终端输出如下:
```plantext
协作任务:

创作一本关于"拖延症心理学"的短篇电子书，目标读者是对心理学感兴趣的普通大众。
要求：
1. 内容科学严谨，基于实证研究
2. 语言通俗易懂，避免过多专业术语
3. 包含实用的改善建议和案例分析
4. 篇幅控制在8000-10000字
5. 结构清晰，包含引言、核心章节和总结


Traceback (most recent call last):
  File "f:\Agent_to_Hero\chapter6\CAMEL_learn\Digital_Book_Writing.py", line 19, in <module>
    role_play_session = RolePlaying(
  File "F:\Anaconda\envs\MLSD_pytorch\lib\site-packages\camel\societies\role_playing.py", line 127, in __init__
    self._init_specified_task_prompt(
  File "F:\Anaconda\envs\MLSD_pytorch\lib\site-packages\camel\societies\role_playing.py", line 218, in _init_specified_task_prompt
    task_specify_agent = TaskSpecifyAgent(
  File "F:\Anaconda\envs\MLSD_pytorch\lib\site-packages\camel\agents\task_agent.py", line 87, in __init__
    super().__init__(
  File "F:\Anaconda\envs\MLSD_pytorch\lib\site-packages\camel\agents\chat_agent.py", line 447, in __init__
    resolved_models = self._resolve_models(model)
  File "F:\Anaconda\envs\MLSD_pytorch\lib\site-packages\camel\agents\chat_agent.py", line 573, in _resolve_models
    return ModelFactory.create(
  File "F:\Anaconda\envs\MLSD_pytorch\lib\site-packages\camel\models\model_factory.py", line 189, in create
    return model_class(
  File "F:\Anaconda\envs\MLSD_pytorch\lib\site-packages\camel\utils\commons.py", line 359, in wrapper
    raise ValueError(
ValueError: Missing or empty required API keys in environment variables: OPENAI_API_KEY.
You can obtain the API key from https://platform.openai.com/docs/overview
```

# 原因分析：

经过研究发现是代码中缺少了关于创建API客户端的代码导致无法直接跑通。

# 解决途径：
对API调用缺失的部分代码进行了补全。