### PR TITLE
fix: replace deprecated qdrant_client.search() with recommended API

### DIFF
--- a/Co-creation-projects/YYHDBL-HelloCodeAgentCli/memory/storage/qdrant_store.py
+++ b/Co-creation-projects/YYHDBL-HelloCodeAgentCli/memory/storage/qdrant_store.py
@@ -377,9 +377,9 @@ class QdrantVectorStore:
                 search_params = models.SearchParams(hnsw_ef=self.search_ef, exact=self.search_exact)
             except Exception:
                 search_params = None
-            search_result = self.client.search(
+            response = self.client.query_points(
                 collection_name=self.collection_name,
-                query_vector=query_vector,
+                query=query_vector,
                 query_filter=query_filter,
                 limit=limit,
                 score_threshold=score_threshold,
@@ -387,6 +387,7 @@ class QdrantVectorStore:
                 with_vectors=False,
                 search_params=search_params
             )
+            search_result = response.points
             
             # 转换结果格式
             results = []


### PR DESCRIPTION
针对第八章常见报错提出解决方法
```bash
❌ 向量搜索失败: 'QdrantClient' object has no attribute 'search'
```

1.16.2的qdrant_client模块弃用了search方法，解决方法是将
```python
            search_result = self.client.search(
                collection_name=self.collection_name,
                query_vector=query_vector,
                query_filter=query_filter,
                limit=limit,
                score_threshold=score_threshold,
                with_payload=True,
                with_vectors=False,
                search_params=search_params
            )
```
修改为
```python
            response = self.client.query_points(
                collection_name=self.collection_name,
                query=query_vector,
                query_filter=query_filter,
                limit=limit,
                score_threshold=score_threshold,
                with_payload=True,
                with_vectors=False,
                search_params=search_params
            )
            search_result = response.points
```