### PR TITLE
fix(ch4): 修复 SerpApi 搜索示例的环境变量加载

### DIFF
--- a/docs/chapter4/第四章 智能体经典范式构建.md
+++ b/docs/chapter4/第四章 智能体经典范式构建.md
@@ -203,7 +203,13 @@ SERPAPI_API_KEY="YOUR_SERPAPI_API_KEY"
 我们的第一个工具是 `search` 函数，它的作用是接收一个查询字符串，然后返回搜索结果。
 
 ```python
+import os
+
+from dotenv import load_dotenv
 from serpapi import SerpApiClient
+
+# 加载 .env 文件中的环境变量
+load_dotenv()
 
 def search(query: str) -> str:
     """


### PR DESCRIPTION
第四章中 `search` 工具示例会读取 `SERPAPI_API_KEY`，但代码片段缺少 `import os`，也未显式加载 `.env`。

本 PR 补充了相关导入和 `load_dotenv()`，让示例代码更完整、更容易按教程直接运行。
