### PR TITLE
feat: add MiniMax provider support to chapter7 custom LLM example

### DIFF
--- a/code/chapter7/.env.example
+++ b/code/chapter7/.env.example
@@ -30,3 +30,17 @@ LLM_TIMEOUT=60
 
 # SerpApi搜索（备选）- 获取API密钥：https://serpapi.com/
 # SERPAPI_API_KEY=your_serpapi_key_here
+
+# ============================================================================
+# 🤖 自定义 Provider 配置示例
+# ============================================================================
+
+# --- ModelScope Provider ---
+# 获取 API Key：https://modelscope.cn/
+# MODELSCOPE_API_KEY=your_modelscope_key_here
+
+# --- MiniMax Provider ---
+# MiniMax 提供 OpenAI 兼容接口，支持 MiniMax-M2.7 和 MiniMax-M2.7-highspeed 模型
+# 获取 API Key：https://platform.minimax.io/
+# MINIMAX_API_KEY=your_minimax_key_here
+# MINIMAX_BASE_URL=https://api.minimax.io/v1

--- a/code/chapter7/my_llm.py
+++ b/code/chapter7/my_llm.py
@@ -17,11 +17,11 @@ class MyLLM(HelloAgentsLLM):
         if provider == "modelscope":
             print("正在使用自定义的 ModelScope Provider")
             self.provider = "modelscope"
-            
+
             # 解析 ModelScope 的凭证
             self.api_key = api_key or os.getenv("MODELSCOPE_API_KEY")
             self.base_url = base_url or "https://api-inference.modelscope.cn/v1/"
-            
+
             # 验证凭证是否存在
             if not self.api_key:
                 raise ValueError("ModelScope API key not found. Please set MODELSCOPE_API_KEY environment variable.")
@@ -31,10 +31,38 @@ class MyLLM(HelloAgentsLLM):
             self.temperature = kwargs.get('temperature', 0.7)
             self.max_tokens = kwargs.get('max_tokens')
             self.timeout = kwargs.get('timeout', 60)
-            
+
             # 使用获取的参数创建OpenAI客户端实例
             self._client = OpenAI(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout)
 
+        elif provider == "minimax":
+            # MiniMax 提供 OpenAI 兼容接口，可直接使用 OpenAI SDK 调用
+            # 支持的模型：MiniMax-M2.7（旗舰版）、MiniMax-M2.7-highspeed（快速版）
+            # 获取 API Key：https://platform.minimax.io/
+            print("正在使用自定义的 MiniMax Provider")
+            self.provider = "minimax"
+
+            # 解析 MiniMax 的凭证
+            self.api_key = api_key or os.getenv("MINIMAX_API_KEY")
+            self.base_url = base_url or os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
+
+            # 验证凭证是否存在
+            if not self.api_key:
+                raise ValueError(
+                    "MiniMax API key not found. Please set MINIMAX_API_KEY environment variable."
+                )
+
+            # 设置默认模型和其他参数
+            # MiniMax-M2.7 是旗舰模型，MiniMax-M2.7-highspeed 是高速版本
+            self.model = model or os.getenv("LLM_MODEL_ID") or "MiniMax-M2.7"
+            # MiniMax temperature 范围为 (0.0, 1.0]，不支持 0，默认使用 1.0
+            self.temperature = kwargs.get('temperature', 1.0)
+            self.max_tokens = kwargs.get('max_tokens')
+            self.timeout = kwargs.get('timeout', 60)
+
+            # 使用 OpenAI SDK 创建客户端（MiniMax 兼容 OpenAI 接口规范）
+            self._client = OpenAI(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout)
+
         else:
-            # 如果不是 modelscope, 则完全使用父类的原始逻辑来处理
+            # 如果不是 modelscope 或 minimax, 则完全使用父类的原始逻辑来处理
             super().__init__(model=model, api_key=api_key, base_url=base_url, provider=provider, **kwargs)

--- a/code/chapter7/test_minimax_llm.py
+++ b/code/chapter7/test_minimax_llm.py
@@ -1,0 +1,125 @@
+# test_minimax_llm.py
+"""
+MiniMax Provider 单元测试
+
+测试 MyLLM 中新增的 MiniMax provider 配置逻辑。
+MiniMax 提供 OpenAI 兼容接口，支持以下模型：
+  - MiniMax-M2.7          旗舰版
+  - MiniMax-M2.7-highspeed  高速版
+
+运行方式：
+    python test_minimax_llm.py
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestMiniMaxProvider(unittest.TestCase):
+    """测试 MiniMax provider 的配置解析逻辑（不调用真实 API）"""
+
+    def _make_llm(self, **kwargs):
+        """辅助方法：创建 MyLLM 实例（mock OpenAI 客户端）"""
+        with patch("my_llm.OpenAI") as mock_openai_cls:
+            mock_openai_cls.return_value = MagicMock()
+            from my_llm import MyLLM
+            llm = MyLLM(provider="minimax", **kwargs)
+            return llm, mock_openai_cls
+
+    def setUp(self):
+        # 重置模块缓存，避免测试间互相影响
+        if "my_llm" in sys.modules:
+            del sys.modules["my_llm"]
+
+    def test_raises_when_api_key_missing(self):
+        """未设置 API Key 时应抛出 ValueError"""
+        with patch.dict(os.environ, {}, clear=True):
+            # 清除可能存在的 MINIMAX_API_KEY
+            os.environ.pop("MINIMAX_API_KEY", None)
+            with patch("my_llm.OpenAI"):
+                from my_llm import MyLLM
+                with self.assertRaises(ValueError) as ctx:
+                    MyLLM(provider="minimax")
+                self.assertIn("MINIMAX_API_KEY", str(ctx.exception))
+
+    def test_default_model_is_minimax_m27(self):
+        """未指定模型时，默认应为 MiniMax-M2.7"""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False):
+            llm, _ = self._make_llm()
+            self.assertEqual(llm.model, "MiniMax-M2.7")
+
+    def test_custom_model_is_respected(self):
+        """显式传入模型名称时，应使用传入的值"""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False):
+            llm, _ = self._make_llm(model="MiniMax-M2.7-highspeed")
+            self.assertEqual(llm.model, "MiniMax-M2.7-highspeed")
+
+    def test_default_base_url(self):
+        """默认 base URL 应指向海外版 api.minimax.io"""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False):
+            os.environ.pop("MINIMAX_BASE_URL", None)
+            llm, mock_openai_cls = self._make_llm()
+            called_url = mock_openai_cls.call_args.kwargs.get("base_url") or \
+                         mock_openai_cls.call_args[1].get("base_url")
+            self.assertIn("api.minimax.io", called_url)
+
+    def test_custom_base_url(self):
+        """显式传入 base_url 时，应使用传入的值"""
+        custom_url = "https://custom.minimax.io/v1"
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False):
+            llm, mock_openai_cls = self._make_llm(base_url=custom_url)
+            called_url = mock_openai_cls.call_args.kwargs.get("base_url") or \
+                         mock_openai_cls.call_args[1].get("base_url")
+            self.assertEqual(called_url, custom_url)
+
+    def test_default_temperature_is_1(self):
+        """MiniMax temperature 默认值应为 1.0（不支持 0）"""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False):
+            llm, _ = self._make_llm()
+            self.assertEqual(llm.temperature, 1.0)
+
+    def test_api_key_from_env(self):
+        """未传入 api_key 时，应从 MINIMAX_API_KEY 环境变量读取"""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-test-key"}, clear=False):
+            llm, mock_openai_cls = self._make_llm()
+            called_api_key = mock_openai_cls.call_args.kwargs.get("api_key") or \
+                             mock_openai_cls.call_args[1].get("api_key")
+            self.assertEqual(called_api_key, "env-test-key")
+
+    def test_api_key_from_argument_overrides_env(self):
+        """传入 api_key 参数时，应优先于环境变量"""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}, clear=False):
+            llm, mock_openai_cls = self._make_llm(api_key="arg-key")
+            called_api_key = mock_openai_cls.call_args.kwargs.get("api_key") or \
+                             mock_openai_cls.call_args[1].get("api_key")
+            self.assertEqual(called_api_key, "arg-key")
+
+
+class TestMiniMaxProviderSelection(unittest.TestCase):
+    """测试 provider 路由逻辑"""
+
+    def setUp(self):
+        if "my_llm" in sys.modules:
+            del sys.modules["my_llm"]
+
+    def test_minimax_provider_selected(self):
+        """provider='minimax' 应触发 MiniMax 分支，打印对应提示"""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False):
+            with patch("my_llm.OpenAI"):
+                from my_llm import MyLLM
+                import io
+                from contextlib import redirect_stdout
+                f = io.StringIO()
+                with redirect_stdout(f):
+                    llm = MyLLM(provider="minimax")
+                output = f.getvalue()
+                self.assertIn("MiniMax", output)
+                self.assertEqual(llm.provider, "minimax")
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("MiniMax Provider 单元测试")
+    print("=" * 60)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This PR adds MiniMax as a custom LLM provider in the Chapter 7 example code, following the same pattern as the existing ModelScope provider.

### Changes

- **`code/chapter7/my_llm.py`**: Add `provider='minimax'` branch to `MyLLM`, demonstrating how to integrate MiniMax's OpenAI-compatible API
  - Reads credentials from `MINIMAX_API_KEY` environment variable
  - Default model: `MiniMax-M2.7` (flagship); also supports `MiniMax-M2.7-highspeed`
  - Sets `temperature` default to `1.0` (MiniMax does not accept `0`)
  - Uses the international endpoint `https://api.minimax.io/v1`
- **`code/chapter7/.env.example`**: Add `MINIMAX_API_KEY` and `MINIMAX_BASE_URL` configuration comments
- **`code/chapter7/test_minimax_llm.py`**: Unit tests (9 cases) covering configuration parsing, default values, error handling, and provider routing — all pass without a real API key

### How to use

```python
from my_llm import MyLLM

llm = MyLLM(provider="minimax")  # reads MINIMAX_API_KEY from env
messages = [{"role": "user", "content": "你好！"}]
for chunk in llm.think(messages):
    pass
```

### API reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api