### PR TITLE
fix: 修正README中过时的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
 
 &emsp;&emsp;*<strong>本 Hello-Agents PDF 教程完全开源免费。为防止各类营销号加水印后贩卖给多智能体系统初学者，我们特地在 PDF 文件中预先添加了不影响阅读的 Datawhale 开源标志水印，敬请谅解～</strong>*
 
-> *Hello-Agents PDF : https://github.com/datawhalechina/hello-agents/releases/tag/V1.0.0*  
+> *Hello-Agents PDF : https://github.com/datawhalechina/hello-agents/releases/latest/*  
 > *Hello-Agents PDF 国内下载地址 : https://www.datawhale.cn/learn/summary/239* 
 
 ## 💡 如何学习

--- a/README_EN.md
+++ b/README_EN.md
@@ -95,7 +95,7 @@ If you wish to read locally or contribute content, please refer to the learning 
 
 &emsp;&emsp;*<strong>This Hello-Agents PDF tutorial is completely open source and free. To prevent various marketing accounts from adding watermarks and selling it to multi-agent system beginners, we have pre-added a Datawhale open source logo watermark that does not affect reading in the PDF file. Please understand~</strong>*
 
-> *Hello-Agents PDF: https://github.com/datawhalechina/hello-agents/releases/tag/V1.0.0*  
+> *Hello-Agents PDF: https://github.com/datawhalechina/hello-agents/releases/latest/*  
 > *Hello-Agents PDF Domestic Download: https://www.datawhale.cn/learn/summary/239* 
 
 ## 💡 How to Learn


### PR DESCRIPTION
## 描述
修正过时的下载链接，现在能跳转最新的下载页面。
## 改动内容
更新了 [PDF 版本下载](https://github.com/datawhalechina/hello-agents#pdf-%E7%89%88%E6%9C%AC%E4%B8%8B%E8%BD%BD) 下的链接：将 [ 1.0.0 版的 PDF Realease链接](https://github.com/datawhalechina/hello-agents/releases/tag/V1.0.0) 替换为 [最新的 Realese 页面](https://github.com/datawhalechina/hello-agents/releases/latest/) 。
同步核对了相关上下文的描述，确保跳转意图一致。
## 验证情况
- [x] 已在本地环境预览 Markdown 渲染效果。
- [x] 已手动验证新链接，确认可正常跳转且内容准确。