### PR TITLE
Fix:修复13章旅行助手代码因为自动扩展字段失效，无法利用amap工具的问题

### DIFF
--- a/code/chapter13/helloagents-trip-planner/backend/app/agents/trip_planner_agent.py
+++ b/code/chapter13/helloagents-trip-planner/backend/app/agents/trip_planner_agent.py
@@ -172,6 +172,7 @@ class MultiAgentTripPlanner:
                 env={"AMAP_MAPS_API_KEY": settings.amap_api_key},
                 auto_expand=True
             )
+            self.amap_tool.expandable=True
 
             # 创建景点搜索Agent
             print("  - 创建景点搜索Agent...")


### PR DESCRIPTION
1.ToolRegistry 判断工具是否需要展开时，需要auto_expand 、hasattr(tool, 'expandable') 、tool.expandable 三个条件都同时满足
2.MCPTool 初始化时虽然有 auto_expand=true ，但没有把父类 Tool 的 expandable 属性设为真，导致 tool.expandable 仍是父类 Tool 中设置的默认值 false，从而使得 ToolRegistry 永远不会执行展开的代码逻辑
3.最终导致了高德的 MCP 工具无法正常使用

如果要正常使用高德 MCP 工具，还需要手动指定 self.amap_tool.expandable=True