### PR TITLE
fix: 修复流式响应空choices导致的IndexError

### DIFF
--- a/code/chapter4/llm_client.py
+++ b/code/chapter4/llm_client.py
@@ -42,9 +42,12 @@ class HelloAgentsLLM:
             print("✅ 大语言模型响应成功:")
             collected_content = []
             for chunk in response:
-                content = chunk.choices[0].delta.content or ""
-                print(content, end="", flush=True)
-                collected_content.append(content)
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                if delta.content:
+                    print(delta.content, end="", flush=True)
+                    collected_content.append(delta.content)
             print()  # 在流式输出结束后换行
             return "".join(collected_content)
 

--- a/docs/chapter4/Chapter4-Building-Classic-Agent-Paradigms.md
+++ b/docs/chapter4/Chapter4-Building-Classic-Agent-Paradigms.md
@@ -92,9 +92,12 @@ class HelloAgentsLLM:
             print("✅ Large language model response successful:")
             collected_content = []
             for chunk in response:
-                content = chunk.choices[0].delta.content or ""
-                print(content, end="", flush=True)
-                collected_content.append(content)
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                if delta.content:
+                    print(delta.content, end="", flush=True)
+                    collected_content.append(delta.content)
             print()  # Newline after streaming output ends
             return "".join(collected_content)
 

--- a/docs/chapter4/第四章 智能体经典范式构建.md
+++ b/docs/chapter4/第四章 智能体经典范式构建.md
@@ -92,9 +92,12 @@ class HelloAgentsLLM:
             print("✅ 大语言模型响应成功:")
             collected_content = []
             for chunk in response:
-                content = chunk.choices[0].delta.content or ""
-                print(content, end="", flush=True)
-                collected_content.append(content)
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                if delta.content:
+                    print(delta.content, end="", flush=True)
+                    collected_content.append(delta.content)
             print()  # 在流式输出结束后换行
             return "".join(collected_content)
 


### PR DESCRIPTION
我在使用第三方的LlmApi时候会出现如下问题
<img width="608" height="50" alt="图片" src="https://github.com/user-attachments/assets/de2fc61c-4c28-44c0-b1d6-3839e76d14d2" />
经过排查发现问题如下：
在绝大多数情况下，流式响应返回的 chunk 结构是这样的，包含一个非空的 choices 列表：
```JSON
// 正常的 chunk
{
  "id": "chatcmpl-123",
  "choices": [
    {"delta": {"content": "你好"}, "index": 0}
  ]
}
```
但是，当使用兼容 OpenAI 接口的第三方服务，或者在 OpenAI 官方接口中开启了返回 Token 消耗统计（stream_options={"include_usage": True}）时，最后一个 chunk 往往是用来汇总信息的。此时，choices 列表可能是空的：

```JSON
// 最后一个汇总 chunk (包含 usage 统计)
{
  "id": "chatcmpl-123",
  "choices": [],  // 注意这里：列表是空的！
  "usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60}
}
```

对一个空列表强行执行 chunk.choices[0]，Python 就会立刻抛出 IndexError: list index out of range 错误，这导致了刚刚的问题。

对此我进行了一些修复改正。

**事实上，这可能并不是什么大问题，您可以看情况考虑是否要采纳。**