### PR TITLE
fix: path traversal in PDF analysis endpoint (CWE-22)

### DIFF
--- a/Co-creation-projects/Apricity-InnocoreAI/api/routes/analysis.py
+++ b/Co-creation-projects/Apricity-InnocoreAI/api/routes/analysis.py
@@ -60,10 +60,17 @@ async def analyze_paper(request: PaperAnalysisRequest):
             
             # 构建完整的文件路径
             if paper_url.startswith('/uploads/'):
-                # 假设上传的文件在 downloads 目录
-                file_path = os.path.join('downloads', paper_url.replace('/uploads/', ''))
+                # Sanitize filename to prevent path traversal
+                safe_name = os.path.basename(paper_url)
+                if not safe_name or not safe_name.endswith('.pdf'):
+                    raise HTTPException(status_code=400, detail="无效的文件名")
+                file_path = os.path.join('downloads', safe_name)
             else:
-                file_path = paper_url
+                # For non-upload paths, also sanitize to prevent arbitrary file access
+                safe_name = os.path.basename(paper_url)
+                if not safe_name or not safe_name.endswith('.pdf'):
+                    raise HTTPException(status_code=400, detail="无效的文件名")
+                file_path = os.path.join('downloads', safe_name)
             
             # 检查文件是否存在
             if not os.path.exists(file_path):
@@ -541,7 +548,10 @@ async def upload_pdf_for_analysis(file: UploadFile = File(...)):
         
         # 保存文件到 downloads 目录
         os.makedirs("downloads", exist_ok=True)
-        file_path = os.path.join("downloads", file.filename)
+        safe_filename = os.path.basename(file.filename)
+        if not safe_filename:
+            raise HTTPException(status_code=400, detail="无效的文件名")
+        file_path = os.path.join("downloads", safe_filename)
         
         with open(file_path, "wb") as f:
             f.write(pdf_bytes)
@@ -550,8 +560,8 @@ async def upload_pdf_for_analysis(file: UploadFile = File(...)):
         
         return {
             "success": True,
-            "filename": file.filename,
-            "file_path": f"/uploads/{file.filename}",
+            "filename": safe_filename,
+            "file_path": f"/uploads/{safe_filename}",
             "title": pdf_result.get("title", "未知标题"),
             "authors": pdf_result.get("authors", ["未知作者"]),
             "abstract": pdf_result.get("abstract", "")[:500],  # 限制摘要长度


### PR DESCRIPTION
## Path Traversal in PDF Analysis Endpoint (CWE-22)

### Vulnerability Summary

**CWE-22 — Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal")**
**Severity: High**
**Affected file:** `Co-creation-projects/Apricity-InnocoreAI/api/routes/analysis.py`
**Affected functions:** `analyze_paper` and `upload_pdf_for_analysis`

Two related path traversal weaknesses existed in the PDF analysis API:

1. **`upload_pdf_for_analysis`** — the `file.filename` value supplied by the client was passed directly to `os.path.join("downloads", file.filename)` without sanitization. A client could supply a filename like `../../etc/passwd` or `../config/secrets.env`, causing the server to write the uploaded file outside the intended `downloads/` directory.

2. **`analyze_paper`** — the `paper_url` field from the request body was used to construct a file path via `os.path.join('downloads', paper_url.replace('/uploads/', ''))`. An attacker could supply a value such as `/uploads/../../sensitive_file` to cause the path join to resolve outside the downloads directory, then trigger a read of that file through the analysis pipeline.

Both endpoints are unauthenticated (no auth dependency is applied before the path is constructed), meaning any network-reachable client can exploit these without credentials.

**Data flow (upload):**
`POST /upload → file.filename (client-controlled) → os.path.join("downloads", file.filename) → open() write`

**Data flow (analyze):**
`POST /analyze → request.paper_url (client-controlled) → os.path.join('downloads', ...) → file read + LLM analysis`

---

### Fix Description

Both sinks are now guarded with `os.path.basename()` before any path join:

```python
# Upload endpoint
safe_filename = os.path.basename(file.filename)
if not safe_filename:
    raise HTTPException(status_code=400, detail="无效的文件名")
file_path = os.path.join("downloads", safe_filename)

# Analysis endpoint
safe_name = os.path.basename(paper_url)
if not safe_name or not safe_name.endswith('.pdf'):
    raise HTTPException(status_code=400, detail="无效的文件名")
file_path = os.path.join('downloads', safe_name)
```

`os.path.basename()` strips all directory components from the supplied value, ensuring the resulting filename contains no path separators. The empty-string check catches inputs that reduce to nothing after stripping (e.g. a bare `/`). The `.pdf` extension check on the analysis path adds an additional type gate, preventing the analysis endpoint from being repurposed to exfiltrate arbitrary file content via the LLM response.

The response from the upload endpoint is also updated to echo `safe_filename` rather than the raw `file.filename`, ensuring the stored path reference is consistent with what was actually written to disk.

---

### Test Results

Manual verification against the patched code:

| Input | Before | After |
|---|---|---|
| `../../etc/passwd` | Writes/reads outside `downloads/` | Resolved to `passwd`, rejected (no `.pdf`) or safely placed in `downloads/` |
| `/uploads/../../secrets.env` | Traverses up two directories | Resolved to `secrets.env`, rejected (no `.pdf`) |
| `report.pdf` | Works | Works as expected |
| `/uploads/paper.pdf` | Works | Works as expected |
| (empty string after basename) | Varies | 400 returned |

No regressions observed in normal upload/analysis flow.

---

### Security Analysis

**Exploitability:** High. Both endpoints accept unauthenticated POST requests. The upload traversal allows arbitrary file write to any directory the server process can write to — including overwriting application code, cron scripts, or SSH authorized_keys depending on deployment context. The analysis traversal allows reading arbitrary files the process can access, with results surfaced through the LLM analysis response.

**Preconditions:** Network access to the API. No authentication, no API key, no prior session required.

**Mitigations provided by this fix:**
- All path components from client input are stripped before use
- Empty filenames are explicitly rejected with a 400
- The analysis endpoint enforces a `.pdf` extension gate, narrowing the attack surface even if a future bypass of `basename` were discovered
- The server response no longer echoes unsanitized client-supplied filenames

---

### Adversarial Review

Before submitting, we scrutinised whether existing controls would render this unexploitable in practice. The framework (FastAPI) performs no automatic filename sanitization — it passes `UploadFile.filename` through as received from the multipart header. There is no middleware visible in this project that normalises or validates file paths. The endpoints carry no auth dependency injection. The `os.path.join` behaviour on Python is well-understood: a component containing `..` will traverse upward, and a component beginning with `/` will discard the base entirely on POSIX systems. None of the deployment assumptions visible in the codebase would prevent a straightforward traversal. The finding stands.

---

cc @lewiswigmore
