### PR TITLE
fix(chapter4): skip empty choices chunks in streaming response

### DIFF
--- a/code/chapter4/llm_client.py
+++ b/code/chapter4/llm_client.py
@@ -42,6 +42,8 @@ class HelloAgentsLLM:
             print("✅ 大语言模型响应成功:")
             collected_content = []
             for chunk in response:
+                if not chunk.choices:
+                    continue
                 content = chunk.choices[0].delta.content or ""
                 print(content, end="", flush=True)
                 collected_content.append(content)

--- a/docs/chapter4/Chapter4-Building-Classic-Agent-Paradigms.md
+++ b/docs/chapter4/Chapter4-Building-Classic-Agent-Paradigms.md
@@ -92,6 +92,8 @@ class HelloAgentsLLM:
             print("✅ Large language model response successful:")
             collected_content = []
             for chunk in response:
+                if not chunk.choices:
+                    continue
                 content = chunk.choices[0].delta.content or ""
                 print(content, end="", flush=True)
                 collected_content.append(content)

--- a/docs/chapter4/第四章 智能体经典范式构建.md
+++ b/docs/chapter4/第四章 智能体经典范式构建.md
@@ -92,6 +92,8 @@ class HelloAgentsLLM:
             print("✅ 大语言模型响应成功:")
             collected_content = []
             for chunk in response:
+                if not chunk.choices:
+                    continue
                 content = chunk.choices[0].delta.content or ""
                 print(content, end="", flush=True)
                 collected_content.append(content)


### PR DESCRIPTION
## 问题描述                                                                                                                          
                                                                                                                                       
关闭 #522                                                                                                                            
                                                                                                                                       
  部分 OpenAI 兼容 API（如 AIHubMix）在流式响应结束时会发送一个尾包，其 `choices` 字段为空数组，仅包含用量统计。`llm_client.py` 第 45行直接访问 `chunk.choices[0]`，在遇到此尾包时抛出 `IndexError`。                                                                     
                                                                  
  更隐蔽的是：该异常被第 51 行的 `except Exception` 吞掉并返回 `None`，导致模型已正确输出的内容被**全部丢弃**，调用方拿到的是空结果。
                                                                                                                                       
## 复现                                 
                                                                                                                                       
  ```python                                                                                                                            
  # 模拟含尾包的流
  stream = [chunk("北京今天"), chunk("天气晴朗"), empty_chunk()]                                                                       
  # 输出：                                                      
  # ✅ 大语言模型响应成功:                    
  # 北京今天天气晴朗❌ 调用LLM API时发生错误: list index out of range
  # result: None   ← 内容全部丢失 
```                                                                                                     
                                                                                                                                       
## 修复                                                                                                                                 
                                                                                                                                       
  ### 修复前                                                                                                                             
  for chunk in response:
      content = chunk.choices[0].delta.content or ""                                                                                   
                                                            
  ### 修复后       
```                                                                                                                      
  for chunk in response:                                    
      if not chunk.choices:                                                                                                            
          continue
      content = chunk.choices[0].delta.content or "" 
```                                                                                  
                                                            
## 验证

  修复后，尾包被跳过，已接收的内容完整保留：  
  ✅ 大语言模型响应成功:
  北京今天天气晴朗
  result: '北京今天天气晴朗'                  
  ✅ Fix verified — content preserved, no crash

## 自检清单                                                                                                                                                                                                             
  - 正常 chunk 行为不变                                     
  - 修复了内容被静默丢弃的问题