### PR TITLE
fix: prevent path traversal in Apricity-InnocoreAI analysis endpoints (CWE-22)

### DIFF
--- a/Co-creation-projects/Apricity-InnocoreAI/api/routes/analysis.py
+++ b/Co-creation-projects/Apricity-InnocoreAI/api/routes/analysis.py
@@ -61,7 +61,8 @@ async def analyze_paper(request: PaperAnalysisRequest):
             # 构建完整的文件路径
             if paper_url.startswith('/uploads/'):
                 # 假设上传的文件在 downloads 目录
-                file_path = os.path.join('downloads', paper_url.replace('/uploads/', ''))
+                safe_name = os.path.basename(paper_url.replace('/uploads/', ''))
+                file_path = os.path.join('downloads', safe_name)
             else:
                 file_path = paper_url
             
@@ -541,7 +542,10 @@ async def upload_pdf_for_analysis(file: UploadFile = File(...)):
         
         # 保存文件到 downloads 目录
         os.makedirs("downloads", exist_ok=True)
-        file_path = os.path.join("downloads", file.filename)
+        safe_filename = os.path.basename(file.filename)
+        if not safe_filename:
+            raise HTTPException(status_code=400, detail="无效的文件名")
+        file_path = os.path.join("downloads", safe_filename)
         
         with open(file_path, "wb") as f:
             f.write(pdf_bytes)


### PR DESCRIPTION
## Summary

This PR fixes a path traversal vulnerability (CWE-22) in two FastAPI endpoints in `Co-creation-projects/Apricity-InnocoreAI/api/routes/analysis.py`. Both endpoints accept attacker-controlled filename components and joined them directly into a `downloads/...` path, allowing arbitrary file write and arbitrary PDF read outside of the intended directory.

## Affected code

- `POST /upload-pdf` (around line 542) — used `file.filename` from the multipart upload directly in `os.path.join("downloads", file.filename)`. FastAPI does not sanitize `UploadFile.filename`, so a crafted `Content-Disposition` header with a value like `../../etc/cron.d/x` would write the uploaded bytes outside `downloads/`.
- `POST /analyze` (around line 63) — used `PaperAnalysisRequest.paper_url` directly: when the URL began with `/uploads/`, the remainder was joined into `downloads/`. A value like `/uploads/../../etc/passwd` would resolve to a path outside `downloads/`, which was then opened and processed by the PDF reader path. While a non-PDF file would fail to parse later, the file is still opened for read, and any local PDF on the host becomes readable through the analysis pipeline.

Neither endpoint has an authentication dependency, so the only precondition is network reachability to the API.

## Fix

Apply `os.path.basename()` to strip any directory components from the user-supplied name before joining, and reject empty filenames on upload:

```python
# upload endpoint
safe_filename = os.path.basename(file.filename)
if not safe_filename:
    raise HTTPException(status_code=400, detail="无效的文件名")
file_path = os.path.join("downloads", safe_filename)

# analyze endpoint
safe_name = os.path.basename(paper_url.replace('/uploads/', ''))
file_path = os.path.join('downloads', safe_name)
```

`os.path.basename()` reliably collapses `../` segments and absolute paths down to the trailing name component on POSIX, which is the standard mitigation for this exact pattern. The change is minimal and preserves existing behaviour for legitimate filenames.

## Testing

- Verified the diff is limited to the two sinks (6 added / 2 removed in a single file).
- Manually walked through `os.path.basename()` on representative malicious inputs (`../../etc/passwd`, `/etc/passwd`, `..\\..\\foo`, empty string) to confirm each is reduced to either a harmless basename or rejected.
- Confirmed normal uploads (`report.pdf`) and normal analyze flows (`/uploads/report.pdf`) are unchanged.
- No new dependencies; no behaviour change for legitimate clients.

## Adversarial review

Before submitting, we tried to disprove this. We checked whether FastAPI/Starlette sanitizes `UploadFile.filename` (it does not — the value is taken straight from the multipart `Content-Disposition`), whether any auth dependency or middleware gates the routes (none on these endpoints), and whether the surrounding code performs validation before the `open()` (it does not). We also confirmed `paper_url` is a plain `str` field on the Pydantic model with no validator. The vulnerability is reachable by any unauthenticated network client.

One related concern is out of scope here: when `paper_url` does not start with `/uploads/` and ends in `.pdf`, the code uses it directly as `file_path`, which permits reading arbitrary local PDFs. That is a separate finding and is intentionally not addressed in this minimal patch, which closes only the two `downloads/`-join sinks.

cc @lewiswigmore
