### PR TITLE
Fix shell command injection in HelloCodeAgentCli context_fetch grep fallback (CWE-78)

### DIFF
--- a/Co-creation-projects/YYHDBL-HelloCodeAgentCli/tools/builtin/context_fetch_tool.py
+++ b/Co-creation-projects/YYHDBL-HelloCodeAgentCli/tools/builtin/context_fetch_tool.py
@@ -203,17 +203,33 @@ class ContextFetchTool(Tool):
     def _fetch_files_fallback(self, query: str, paths: str, budget: int) -> str:
         """ripgrep 不可用时的降级方案"""
         try:
-            cmd = f"grep -rn '{query}' {self.workspace}"
             if paths:
-                cmd = f"find {self.workspace} -path '{paths}' -type f | xargs grep -n '{query}'"
-            
-            result = subprocess.run(
-                cmd,
-                shell=True,
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
+                # 使用 find 列出匹配路径模式的文件，再用 grep 搜索
+                # 使用参数列表（shell=False）避免命令注入（CWE-78）
+                find_result = subprocess.run(
+                    ["find", self.workspace, "-path", paths, "-type", "f"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                files = [f for f in find_result.stdout.strip().splitlines() if f]
+                if not files:
+                    return f"[files] 未找到匹配 '{query}' 的内容"
+                # 使用 "--" 防止 query 被解释为选项
+                result = subprocess.run(
+                    ["grep", "-n", "--", query, *files],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            else:
+                # 使用 "--" 防止 query 被解释为选项
+                result = subprocess.run(
+                    ["grep", "-rn", "--", query, self.workspace],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
             output = result.stdout.strip()
             if output:
                 return f"[files] grep 结果:\n{self._truncate(output, budget)}"


### PR DESCRIPTION
## Summary

Fixes a shell command injection (CWE-78) in `Co-creation-projects/YYHDBL-HelloCodeAgentCli/tools/builtin/context_fetch_tool.py` in the `_fetch_files_fallback` method of `ContextFetchTool`. This is the fallback path used when `ripgrep` is not installed.

## Vulnerability

The fallback built a shell command via f-string interpolation of the LLM-supplied `query` (and `paths`) arguments and ran it with `shell=True`:

```python
cmd = f"grep -rn '{query}' {self.workspace}"
if paths:
    cmd = f"find {self.workspace} -path '{paths}' -type f | xargs grep -n '{query}'"
result = subprocess.run(cmd, shell=True, ...)
```

A single quote inside `query` closes the quoted string and lets any shell metacharacters that follow execute. For example a query like `foo'; id; echo '` causes `id` to run as the user invoking the agent.

Because this is a coding-agent CLI, the values of `query`/`paths` come from the LLM's tool call. They can be influenced two ways:

1. Directly, by a user request that asks the agent to search for an attacker-chosen string.
2. Indirectly via prompt injection — e.g. the agent is asked to summarise a file/page whose contents instruct it to call `context_fetch` with a payload. This class of indirect injection against coding agents is well documented.

The fallback path triggers when `ripgrep` is not available, which is common on minimal Linux/macOS setups and CI containers.

## Fix

Replace `shell=True` with argv-list invocations of `find` and `grep`. The query and workspace path are passed as separate argv elements and never re-parsed by a shell, so quotes and metacharacters are inert. `--` is added before `query` so a value beginning with `-` is treated as a search pattern rather than a `grep` option (preventing things like `--include`, `-f`, `-d skip`).

Behaviour is otherwise preserved: same timeout, same output formatting, same return value when no matches are found.

```python
if paths:
    find_result = subprocess.run(
        ["find", self.workspace, "-path", paths, "-type", "f"],
        capture_output=True, text=True, timeout=10,
    )
    files = [f for f in find_result.stdout.strip().splitlines() if f]
    if not files:
        return f"[files] 未找到匹配 '{query}' 的内容"
    result = subprocess.run(
        ["grep", "-n", "--", query, *files],
        capture_output=True, text=True, timeout=10,
    )
else:
    result = subprocess.run(
        ["grep", "-rn", "--", query, self.workspace],
        capture_output=True, text=True, timeout=10,
    )
```

Diff is 26 insertions / 10 deletions in a single file.

## Testing

- Reproduced the original issue with a query of `x'; touch /tmp/pwned_ctxfetch; echo '` against the unpatched code — the marker file appeared, confirming arbitrary command execution.
- Re-ran the same query against the patched code — no marker file; `grep` simply searches for the literal string and returns no matches. Tested with several other metacharacter payloads (`` `id` ``, `$(id)`, `; rm -rf x`, `--include=*`) — all are handled as literal search input.
- Verified normal usage still works: queries with spaces, regex characters, Chinese characters, and a non-empty `paths` glob all return results equivalent to the previous `shell=True` invocation.

## Adversarial review

Before submitting, I tried to disprove this. The arguments are not validated or escaped anywhere upstream of `_fetch_files_fallback` — `query` and `paths` are taken directly from the tool-call JSON the LLM emits. The fallback runs unconditionally when ripgrep is unavailable, which is the default on systems without it installed. The preconditions (an LLM that emits attacker-influenced tool arguments) do not by themselves grant code execution on the host — this fallback is the bridge from "LLM produced a bad string" to "shell command runs as the developer", which is why it's worth fixing rather than treating as expected behaviour.

## Scope

Only the `_fetch_files_fallback` method is touched. No other `shell=True` paths in this file are affected.