### PR TITLE
fix(haoye2-UniversalAgent): use shell=False in TerminalTool to prevent command injection (CWE-78)

### DIFF
--- a/Co-creation-projects/haoye2-UnivesalAgent/src/tools/terminal_tool.py
+++ b/Co-creation-projects/haoye2-UnivesalAgent/src/tools/terminal_tool.py
@@ -139,12 +139,14 @@ class TerminalTool:
             if not validation_result[0]:  # 验证失败
                 return validation_result[1]
         
-        # 执行命令（使用 shell=False 提高安全性）
+        # 执行命令（使用 shell=False 防止命令注入）
         try:
-            # 使用 shlex.split 可以正确处理带引号的参数
+            # 传递已经通过 shlex.split 解析的参数列表，避免 shell 解释
+            # 注意: 使用 shell=False 可防止 ;、&&、|、$()、反引号 等元字符
+            # 被 shell 解释执行（CWE-78）。
             result = subprocess.run(
-                cmd,
-                shell=True,  # 保持向后兼容，但需要更严格的白名单
+                [command_name, *args],
+                shell=False,
                 capture_output=True,
                 text=True,
                 timeout=15,


### PR DESCRIPTION
## Summary

Hardens `TerminalTool.run` in `Co-creation-projects/haoye2-UnivesalAgent/src/tools/terminal_tool.py` against OS command injection (CWE-78) by switching `subprocess.run` from `shell=True` to `shell=False` and passing an argv list instead of the raw command string.

## Vulnerability

- **File:** `Co-creation-projects/haoye2-UnivesalAgent/src/tools/terminal_tool.py`
- **Function:** `TerminalTool.run` (the `subprocess.run(...)` call around line 145)
- **CWE:** CWE-78 (OS Command Injection)

The pre-fix code passed the original user-controlled `cmd` string to `subprocess.run(..., shell=True)`. There is a denylist in `_check_command_safety` that blocks substrings like `;`, `|`, `&&`, `` ` ``, `$(`, etc. — but it does **not** block newline (`\n`) or carriage return (`\r`), which bash also treats as command separators.

So an input like:

```
echo hi␊id
```

(where `␊` is a literal newline character) survives the denylist — none of the banned substrings appear, the first token `echo` is whitelisted, and there are no operator tokens to flag — and with `shell=True` bash executes `id` as a second command. The shell metacharacter set the denylist tries to cover is incomplete; that's the core problem with denylist-based shell-injection mitigations.

In this codebase the `input` parameter to `TerminalTool.run` is reachable from agent / LLM output, so prompt injection of the agent is a realistic trigger path. The whitelist + denylist were clearly intended to prevent arbitrary command execution, so this is a real gap rather than something redundant with attacker preconditions.

## Fix

```diff
-            result = subprocess.run(
-                cmd,
-                shell=True,  # 保持向后兼容，但需要更严格的白名单
+            result = subprocess.run(
+                [command_name, *args],
+                shell=False,
```

The arguments come from `shlex.split(cmd)`, which collapses whitespace (including newlines) into token boundaries. With `shell=False`, no shell is invoked, so `;`, `|`, `&&`, `$(...)`, backticks, **and newlines** are all treated as literal characters in argv — none are interpreted as command separators or substitutions. The existing whitelist on `command_name` and per-command argument validation continue to apply unchanged.

This is a defense-in-depth improvement: even if a future change loosens the denylist or a new metacharacter is missed, the absence of a shell means no injection is possible at this sink.

## Testing

- Verified the diff is minimal — one file, six changed lines, no behavior change for legitimate whitelisted commands (the same `command_name` and `args` are executed, just without an intermediate shell).
- Manually constructed the newline payload above and confirmed it bypasses `_check_command_safety` on the pre-fix code path; with the fix applied, the same payload is passed as a single literal argument to the whitelisted binary instead of being parsed as two commands.
- `shlex.split` already runs before the safety check uses it, so this change does not alter what inputs are accepted — only how the accepted argv is dispatched.

## Adversarial review

Before submitting, we tried to disprove this. The questions we asked: (1) Is the denylist actually exhaustive? It is not — newline / `\r` are absent, and bash treats them as statement separators. (2) Does the whitelist on `command_name` save us? No — `shlex.split("echo hi\nid")` returns `['echo', 'hi', 'id']`, so `command_name` is the whitelisted `echo` while the injected `id` would only execute under `shell=True` bash re-parsing of the original string. (3) Is the agent's `input` parameter actually attacker-influenceable? Yes — TerminalTool is exposed as an agent tool, so prompt injection of the LLM is a realistic source. None of the existing mitigations close the gap, so the fix is warranted.

## Scope

Only the `subprocess.run` invocation changes. No public API, no whitelist contents, no validation logic, and no return values are modified.