### PR TITLE
fix: 修复 chapter9 示例中的 LLMResponse 类型问题

### DIFF
--- a/code/chapter9/02_context_builder_with_agent.py
+++ b/code/chapter9/02_context_builder_with_agent.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 from hello_agents import SimpleAgent, HelloAgentsLLM, ToolRegistry
 from hello_agents.context import ContextBuilder, ContextConfig
-from hello_agents.tools import MemoryTool, RAGTool
+#from hello_agents.tools import MemoryTool, RAGTool
 from hello_agents.core.message import Message
 from datetime import datetime
 
@@ -50,7 +50,7 @@ class ContextAwareAgent(SimpleAgent):
             {"role": "system", "content": optimized_context},
             {"role": "user", "content": user_input}
         ]
-        response = self.llm.invoke(messages)
+        response = self.llm.invoke(messages).content
 
         # 3. 更新对话历史
         self.conversation_history.append(


### PR DESCRIPTION
运行 `code/chapter9/02_context_builder_with_agent.py` 时，示例代码在更新对话历史时会出现类型错误。

原因是 `self.llm.invoke(messages)` 返回的是 `LLMResponse` 对象，而 `Message(content=...)` 需要的是字符串内容。

另外，`MemoryTool` 和 `RAGTool` 在当前示例中属于可选功能，相关初始化代码已经被注释，但文件顶部仍然直接导入它们，可能导致示例在未配置相关工具时提前报错。

## 修改

本次主要修改了两处：

1. 注释掉未实际启用的可选工具导入：

```python
# from hello_agents.tools import MemoryTool, RAGTool


2. 从 `LLMResponse` 对象中取出实际文本内容：

```python
response = self.llm.invoke(messages).content
```

这样后续执行：

```python
Message(content=response, role="assistant", timestamp=datetime.now())
```

时，传入的 `response` 是字符串内容，而不是 `LLMResponse` 对象本身，从而避免类型不匹配错误。