### PR TITLE
fix: correct sidebar-toggle background in dark mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -193,6 +193,14 @@
             background-color: var(--theme-color);
             color: white;
         }
+
+        /* 深色模式下修正 docsify 自带 .sidebar-toggle (左下角汉堡) 的浅色背景 */
+        /* vue.css 默认写死 background-color: hsla(0,0%,100%,.8)，并在小屏折叠态
+           (body.close .sidebar-toggle) 下回写同色，这里一并覆盖 */
+        body.dark-mode .sidebar-toggle,
+        body.dark-mode.close .sidebar-toggle {
+            background-color: transparent;
+        }
     </style>
 </head>
 


### PR DESCRIPTION
docsify vue.css 给 .sidebar-toggle 写死了 hsla(0,0%,100%,.8) 的浅色背景， 在 body.dark-mode 作用域下未被覆盖，导致深色模式下左下角汉堡按钮背后出现
浅色块。新增 body.dark-mode 作用域下的覆盖规则（含小屏折叠态
body.dark-mode.close .sidebar-toggle），背景置为 transparent。
<img width="394" height="183" alt="Screenshot 2026-05-30 at 11 31 19 PM" src="https://github.com/user-attachments/assets/02cf6b42-1cdf-4df8-b161-66a006e9ebc5" />
<img width="302" height="120" alt="Screenshot 2026-05-30 at 11 32 06 PM" src="https://github.com/user-attachments/assets/86ddb0cb-3e2a-45d9-b87f-a91ad92ca58d" />
