### PR TITLE
fix: repair Chapter 13 trip planner frontend build

### DIFF
--- a/code/chapter13/helloagents-trip-planner/frontend/src/views/Home.vue
+++ b/code/chapter13/helloagents-trip-planner/frontend/src/views/Home.vue
@@ -216,7 +216,12 @@ const loading = ref(false)
 const loadingProgress = ref(0)
 const loadingStatus = ref('')
 
-const formData = reactive<TripFormData & { start_date: Dayjs | null; end_date: Dayjs | null }>({
+type TripFormState = Omit<TripFormData, 'start_date' | 'end_date'> & {
+  start_date: Dayjs | null
+  end_date: Dayjs | null
+}
+
+const formData = reactive<TripFormState>({
   city: '',
   start_date: null,
   end_date: null,

--- a/code/chapter13/helloagents-trip-planner/frontend/src/views/Result.vue
+++ b/code/chapter13/helloagents-trip-planner/frontend/src/views/Result.vue
@@ -632,6 +632,7 @@ const exportAsImage = async () => {
 // 导出为PDF
 const exportAsPDF = async () => {
   try {
+    await captureMapImage()
     message.loading({ content: '正在生成PDF...', key: 'export', duration: 0 })
 
     const element = document.querySelector('.main-content') as HTMLElement
@@ -778,9 +779,11 @@ const exportAsPDF = async () => {
     }
 
     pdf.save(`旅行计划_${tripPlan.value?.city}_${new Date().getTime()}.pdf`)
+    restoreMap()
 
     message.success({ content: 'PDF导出成功!', key: 'export' })
   } catch (error: any) {
+    restoreMap()
     console.error('导出PDF失败:', error)
     message.error({ content: `导出PDF失败: ${error.message}`, key: 'export' })
   }

--- a/code/chapter13/helloagents-trip-planner/frontend/src/vite-env.d.ts
+++ b/code/chapter13/helloagents-trip-planner/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Fixes #652.

This repairs the Chapter 13 trip planner frontend production build by:
- adding Vite client type declarations for `import.meta.env` and CSS imports
- separating Ant Design Vue date picker state from the API request date string type
- wiring the existing map snapshot/restore helpers into PDF export so strict unused-local checks pass while preserving the intended export behavior

Verification:
- `npm run build`