### PR TITLE
fix(docs): 修正第七章测试案例与框架源码链接

### DIFF
--- a/docs/chapter7/Chapter7-Building-Your-Agent-Framework.md
+++ b/docs/chapter7/Chapter7-Building-Your-Agent-Framework.md
@@ -96,7 +96,7 @@ Before starting to write specific code, we need to first establish a clear archi
 To allow readers to quickly experience the complete functionality of this chapter, we provide a directly installable Python package. You can install the version corresponding to this chapter with the following command:
 
 ```bash
-# hello-agents framework code visible link: https://github.com/jjyaoao/HelloAgents
+# hello-agents framework code visible link: https://github.com/jjyaoao/helloagents
 # Python version needs to be >= 3.10
 pip install "hello-agents==0.1.1"
 ```
@@ -2096,7 +2096,7 @@ Based on the above design and implementation experience, we can summarize the co
 
 ## 7.6 Chapter Summary
 
-Before formally summarizing, we want to share good news with everyone: For all methods and functions implemented in this chapter, complete test cases are provided in the GitHub repository. You can visit [this link](https://github.com/jjyaoao/HelloAgents/blob/main/examples/chapter07_basic_setup.py) to view and run these test codes. This file contains demonstrations of four Agent paradigms, integration tests of the tool system, usage examples of advanced features, and interactive Agent experiences. If you want to verify whether your implementation is correct or want to deeply understand the actual usage of the framework, these test cases will be valuable references.
+Before formally summarizing, we want to share good news with everyone: For all methods and functions implemented in this chapter, complete test cases are provided in the GitHub repository. You can visit [this link](https://github.com/datawhalechina/hello-agents/tree/main/code/chapter7) to view and run these test codes. This directory contains demonstrations of four Agent paradigms, integration tests of the tool system, usage examples of advanced features, and interactive Agent experiences. If you want to verify whether your implementation is correct or want to deeply understand the actual usage of the framework, these test cases will be valuable references.
 
 Looking back at this chapter, we completed a challenging task: step by step, we built a basic agent framework—HelloAgents. This process consistently followed the core principles of "layered decoupling, single responsibility, and unified interfaces."
 

--- a/docs/chapter7/第七章 构建你的Agent框架.md
+++ b/docs/chapter7/第七章 构建你的Agent框架.md
@@ -96,7 +96,7 @@ hello-agents/
 为了让读者能够快速体验本章的完整功能，我们提供了可直接安装的Python包。你可以通过以下命令安装本章对应的版本：
 
 ```bash
-# hello-agents 框架代码可见链接：https://github.com/jjyaoao/HelloAgents
+# hello-agents 框架代码可见链接：https://github.com/jjyaoao/helloagents
 # Python 版本需要>=3.10
 pip install "hello-agents==0.1.1"
 ```
@@ -2146,7 +2146,7 @@ async def test_parallel_execution():
 
 ## 7.6 本章小结
 
-在正式总结之前，我们想告诉大家一个好消息：对于本章实现的所有方法和功能，都在GitHub仓库中提供了完整的测试案例。你可以访问[这个链接](https://github.com/jjyaoao/HelloAgents/blob/main/examples/chapter07_basic_setup.py)查看和运行这些测试代码。这个文件包含了四种Agent范式的演示、工具系统的集成测试、高级功能的使用示例，以及交互式的Agent体验。如果你想验证自己的实现是否正确，或者想深入了解框架的实际使用方式，这些测试案例将是有价值的参考。
+在正式总结之前，我们想告诉大家一个好消息：对于本章实现的所有方法和功能，都在GitHub仓库中提供了完整的测试案例。你可以访问[这个链接](https://github.com/datawhalechina/hello-agents/tree/main/code/chapter7)查看和运行这些测试代码。该目录包含了四种Agent范式的演示、工具系统的集成测试、高级功能的使用示例，以及交互式的Agent体验。如果你想验证自己的实现是否正确，或者想深入了解框架的实际使用方式，这些测试案例将是有价值的参考。
 
 回顾本章，我们完成了一项富有挑战的任务：一步步构建了一个基础的智能体框架——HelloAgents。这个过程始终遵循着“分层解耦、职责单一、接口统一”的核心原则。
 


### PR DESCRIPTION
## Summary
- 将第七章总结处失效的测试案例链接（`jjyaoao/HelloAgents/examples/chapter07_basic_setup.py`，404）更新为当前教程仓库的 `code/chapter7` 目录
- 同步修正 pip 安装注释中的 HelloAgents 框架源码地址（`HelloAgents` → `helloagents`）
- 中英文文档均已更新，并将「这个文件」/「This file」改为「该目录」/「This directory」以匹配实际内容

Fixes #708

## Test plan
- [x] 确认新链接 https://github.com/datawhalechina/hello-agents/tree/main/code/chapter7 可正常访问
- [x] 确认框架源码链接 https://github.com/jjyaoao/helloagents 可正常访问
- [x] 中英文第七章文档均已修改