### PR TITLE
fix(docs): correct GAIA figure caption

### DIFF
--- a/docs/chapter12/Chapter12-Agent-Performance-Evaluation.md
+++ b/docs/chapter12/Chapter12-Agent-Performance-Evaluation.md
@@ -1501,7 +1501,7 @@ As shown in Figure 12.4, fill in information in submission form:
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/datawhalechina/Hello-Agents/main/docs/images/12-figures/12-4.png" alt="" width="85%"/>
-  <p>Figure 12.4 BFCL Evaluation Process Diagram</p>
+  <p>Figure 12.4 GAIA Evaluation Process Diagram</p>
 </div>
 
 Before submission, you can manually check the generated JSONL file:

--- a/docs/chapter12/第十二章 智能体性能评估.md
+++ b/docs/chapter12/第十二章 智能体性能评估.md
@@ -1493,7 +1493,7 @@ https://huggingface.co/spaces/gaia-benchmark/leaderboard
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/datawhalechina/Hello-Agents/main/docs/images/12-figures/12-4.png" alt="" width="85%"/>
-  <p>图 12.4 BFCL 评估流程图</p>
+  <p>图 12.4 GAIA 评估流程图</p>
 </div>
 
 提交前，可以手动检查生成的 JSON 文件：


### PR DESCRIPTION
<img width="1073" height="930" alt="image" src="https://github.com/user-attachments/assets/8fc07ca0-8b81-408a-b562-5beac81a52dc" />
## 修改内容

  修正第 12 章 GAIA 官方排行榜提交部分的图 12.4 图注：

  - 中文版：`BFCL 评估流程图` → `GAIA 评估流程图`
  - 英文版：`BFCL Evaluation Process Diagram` → `GAIA Evaluation Process Diagram`

  ## 问题原因

  图 12.4 展示的是 GAIA 官方排行榜提交页面，但图注误写成了 BFCL，可能是复用前文图注时遗留的笔误。

  ## 影响

  使中英文文档的图注与章节内容及配图保持一致，避免读者混淆 GAIA 和 BFCL。

  ## 检查

  - [x] 已同步修改中文版本
  - [x] 已同步修改英文版本
  - [x] 已确认没有其他使用图 12.4 的语言版本
  - [x] 已运行 `git diff --check`