### PR TITLE
fix(docs): 修复英文版阅读时侧边栏变回中文的问题 / Fix English sidebar reverting to Chinese

### DIFF
--- a/docs/_sidebar_en.md
+++ b/docs/_sidebar_en.md
@@ -1,5 +1,5 @@
 - [Hello-Agents](/en/README_EN.md)
-  - [Preface](./Preface.md)
+  - [Preface](/en/Preface.md)
 
 - <strong>Part I: Fundamentals of Agents and Language Models</strong>
   - [Chapter 1 Introduction to Agents](/en/chapter1/Chapter1-Introduction-to-Agents.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -441,6 +441,29 @@
 
     <!-- 语言切换脚本 (保留原样) -->
     <script>
+        // 英文文档正文中的相对链接(./chapterN/ChapterX...)会丢失 /en/ 路由前缀,
+        // 导致 docsify 按中文路由加载 _sidebar.md。这里检测到无前缀的英文路由时补回 /en/。
+        function normalizeEnRoute() {
+            const hash = decodeURIComponent(window.location.hash);
+            const m = hash.match(/^#\/(?:\.\/)?(chapter\d+\/Chapter[^?]*|Preface(?:\.md)?)(\?.*)?$/);
+            if (m) {
+                window.location.hash = '#/en/' + m[1] + (m[2] || '');
+                return true;
+            }
+            return false;
+        }
+        window.addEventListener('hashchange', normalizeEnRoute);
+        normalizeEnRoute();
+
+        // docsify 路由是 URL 编码且不带 .md 后缀的,查映射表前需要还原
+        function extractFilename(path) {
+            let filename = path.split('/').pop().split('?')[0];
+            if (filename && !filename.endsWith('.md')) {
+                filename += '.md';
+            }
+            return filename;
+        }
+
         // 章节文件名映射
         const chapterMapping = {
             // 中文 -> 英文
@@ -488,7 +511,7 @@
         };
 
         function switchLanguage() {
-            const currentHash = window.location.hash;
+            const currentHash = decodeURIComponent(window.location.hash);
             const langBtn = document.getElementById('langBtn');
 
             // 检测当前语言
@@ -500,7 +523,7 @@
 
                 // 提取文件名
                 const parts = newHash.split('/');
-                const filename = parts[parts.length - 1];
+                const filename = extractFilename(newHash);
 
                 // 查找对应的中文文件名
                 if (chapterMapping.en2zh[filename]) {
@@ -526,7 +549,7 @@
                 } else {
                     // 提取文件名
                     const parts = path.split('/');
-                    const filename = parts[parts.length - 1];
+                    const filename = extractFilename(path);
 
                     // 查找对应的英文文件名
                     if (chapterMapping.zh2en[filename]) {
@@ -548,7 +571,7 @@
 
         // 页面加载时设置按钮文本和检查语言偏好
         window.addEventListener('load', function() {
-            const currentHash = window.location.hash;
+            const currentHash = decodeURIComponent(window.location.hash);
             const langBtn = document.getElementById('langBtn');
             const preferredLang = localStorage.getItem('preferredLanguage');
 
@@ -564,7 +587,7 @@
                         window.location.hash = '#/en/README_EN.md';
                     } else {
                         const parts = path.split('/');
-                        const filename = parts[parts.length - 1];
+                        const filename = extractFilename(path);
 
                         if (chapterMapping.zh2en[filename]) {
                             parts[parts.length - 1] = chapterMapping.zh2en[filename];
@@ -575,7 +598,7 @@
                     // 用户偏好中文,但当前是英文页面
                     let newHash = currentHash.replace('#/', '').replace('en/', '');
                     const parts = newHash.split('/');
-                    const filename = parts[parts.length - 1];
+                    const filename = extractFilename(newHash);
 
                     if (chapterMapping.en2zh[filename]) {
                         parts[parts.length - 1] = chapterMapping.en2zh[filename];


### PR DESCRIPTION

<img width="1539" height="880" alt="Screenshot 2026-07-11 at 6 14 13 pm" src="https://github.com/user-attachments/assets/e294e0c2-78f0-4dbf-8dc2-540cca3a34d6" />
<img width="1539" height="880" alt="Screenshot 2026-07-11 at 6 14 02 pm" src="https://github.com/user-attachments/assets/e9c21c2b-5186-4ffc-a606-8d06ad472836" />
## 问题 / Problem

Fixes #619

在线阅读切换到英文版后，点击正文或部分链接会导致侧边栏变回中文，且点击侧边栏会跳转到中文内容。

When reading the English version, clicking links in the article body causes the sidebar to revert to Chinese, and sidebar clicks then navigate to Chinese content.

## 根因 / Root Cause

1. 英文文档正文中的章节链接为相对路径（`./chapterN/ChapterX...md`），点击后 docsify 路由从 `#/en/...` 变为 `#/./chapterN/...`，**丢失了 `/en/` 语言前缀**；
2. 失去前缀后，侧边栏请求命中 `index.html` 中的兜底 alias 规则 `'/.*/_sidebar.md': '/_sidebar.md'`，加载了中文侧边栏；
3. 另外 `switchLanguage()` 直接用未解码的 `window.location.hash`（中文文件名是 `%E7%AC%AC...` 编码形式，且 docsify 路由不带 `.md` 后缀）查章节映射表，导致从中文章节切换英文时映射失败、只能跳回英文首页。

English summary: relative links inside English pages drop the `/en/` route prefix, so the sidebar alias falls back to the Chinese `_sidebar.md`; additionally the language-switch button looked up the chapter mapping with the URL-encoded, extension-less hash, so chapter-to-chapter switching never matched.

## 修复 / Changes

- `docs/index.html`
  - 新增 `normalizeEnRoute()`：监听 hashchange，检测到丢失 `/en/` 前缀的英文路由（`chapterN/ChapterX...` / `Preface`，英文文件名不会与中文路由冲突）时自动补回前缀；
  - 新增 `extractFilename()`：查映射表前先 `decodeURIComponent`、去掉 query、补全 `.md` 后缀，`switchLanguage()` 与页面加载自动切换均改用它；
- `docs/_sidebar_en.md`：Preface 链接改为 `/en/Preface.md`，保持语言前缀。

## 验证 / Verification

本地 `docsify` 站点手动 + Playwright 全量回归通过：

| 场景 | 结果 |
|------|------|
| 英文首页点正文章节链接（#619 场景） | ✅ 路由保持 `/en/`，英文侧边栏 + 英文内容 |
| 英文侧边栏点任意章节 | ✅ 英文内容 + 英文侧边栏 |
| 中文章节 → English 按钮 | ✅ 精确跳转到对应英文章节（修复前跳回英文首页） |
| 英文章节 → 中文按钮 | ✅ 精确跳转到对应中文章节 |
| 英文侧边栏 Preface 链接 | ✅ 英文内容 + 英文侧边栏 |
| 中文模式全流程 | ✅ 完全不受影响 |
