### PR TITLE
fix(chapter15): load backend .env so LLM_API_KEY is read at startup

### DIFF
--- a/code/chapter15/Helloagents-AI-Town/backend/config.py
+++ b/code/chapter15/Helloagents-AI-Town/backend/config.py
@@ -3,6 +3,10 @@
 import os
 from typing import Optional
 
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
 class Settings:
     """应用配置"""
     
@@ -39,4 +43,3 @@ class Settings:
         return True
 
 settings = Settings()
-

--- a/code/chapter15/Helloagents-AI-Town/backend/requirements.txt
+++ b/code/chapter15/Helloagents-AI-Town/backend/requirements.txt
@@ -3,6 +3,7 @@ fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
 pydantic>=2.0.0
 requests>=2.31.0
+python-dotenv>=1.0.0
 
 # CORS支持
 python-multipart>=0.0.6


### PR DESCRIPTION
## Summary

Chapter 15's AI-Town (赛博小镇) FastAPI backend reads `LLM_API_KEY` (and `LLM_MODEL_ID`, `LLM_BASE_URL`) via `os.getenv` in the `Settings` class body at import time, but nothing in the backend ever calls `load_dotenv()`. A `.env` created per the setup guide is therefore never loaded into the process environment, so the backend prints `警告: 未设置LLM_API_KEY环境变量` on startup even when the key is set.

This adds `load_dotenv()` at the top of `backend/config.py`, before the `Settings` reads run, resolving `.env` relative to the backend directory (`os.path.join(os.path.dirname(__file__), ".env")`) so it works regardless of the launch cwd. It also declares `python-dotenv` in `backend/requirements.txt` so `from dotenv import load_dotenv` resolves. When no `.env` is present, `Settings.validate()` still returns the existing warning, so behavior is unchanged for that case.

Closes #703
