### PR TITLE
fix(docs): 修正第三章参考文献[11]混引 / correct mixed citation [11] in chapter 3

### DIFF
--- a/docs/chapter3/Chapter3-Fundamentals-of-Large-Language-Models.md
+++ b/docs/chapter3/Chapter3-Fundamentals-of-Large-Language-Models.md
@@ -1003,7 +1003,7 @@ This chapter's LLM foundations mainly help everyone better understand large mode
 
 [10] Hoffmann, J., Borgeaud, E., Mensch, A., Buchatskaya, E., Cai, T., Rutherford, R., ... & Sifre, L. (2022). Training Compute-Optimal Large Language Models. arXiv preprint arXiv:2203.07678.
 
-[11] Ji, Z., Lee, N., Fries, R., Yu, T., & Su, D. (2023). Survey of Hallucination in Large Language Models.
+[11] Huang, L., Yu, W., Ma, W., Zhong, W., Feng, Z., Wang, H., ... & Liu, T. (2023). A Survey on Hallucination in Large Language Models: Principles, Taxonomy, Challenges, and Open Questions. arXiv preprint arXiv:2311.05232.
 
 [12] Bender, E. M., Gebru, T., McMillan-Major, A., & Mitchell, M. (2021). On the Dangers of Stochastic Parrots: Can Language Models Be Too Big? .
 

--- a/docs/chapter3/第三章 大语言模型基础.md
+++ b/docs/chapter3/第三章 大语言模型基础.md
@@ -1013,7 +1013,7 @@ print(response)
 
 [10] Hoffmann, J., Borgeaud, E., Mensch, A., Buchatskaya, E., Cai, T., Rutherford, R., ... & Sifre, L. (2022). Training Compute-Optimal Large Language Models. arXiv preprint arXiv:2203.07678.
 
-[11] Ji, Z., Lee, N., Fries, R., Yu, T., & Su, D. (2023). Survey of Hallucination in Large Language Models.
+[11] Huang, L., Yu, W., Ma, W., Zhong, W., Feng, Z., Wang, H., ... & Liu, T. (2023). A Survey on Hallucination in Large Language Models: Principles, Taxonomy, Challenges, and Open Questions. arXiv preprint arXiv:2311.05232.
 
 [12] Bender, E. M., Gebru, T., McMillan-Major, A., & Mitchell, M. (2021). On the Dangers of Stochastic Parrots: Can Language Models Be Too Big? .
 


### PR DESCRIPTION
Fixes #756

## 问题 / Problem

第3章参考文献 [11] 的作者列表与标题分属两篇不同的论文，该条目所指的论文不存在：

- 作者列表属于 Ji et al.《Survey of Hallucination in Natural Language Generation》（arXiv:2202.03629）
- 标题属于 Huang et al.《A Survey on Hallucination in Large Language Models: Principles, Taxonomy, Challenges, and Open Questions》（arXiv:2311.05232）

## 修改 / Fix

将 [11] 改指 Huang et al.，并按文献表既有格式（参照 [9] Kaplan、[10] Hoffmann）补全作者列表与 arXiv 信息。

依据：正文中 [11] 的两处用法（3.3.1 "事实性/忠实性幻觉"分类、3.3.2 "幻觉是 LLM 关键局限性"）均与 Huang et al. 的分类体系和主题对应（详细分析见 #756）。

中英文两版同步修正：

- `docs/chapter3/第三章 大语言模型基础.md`
- `docs/chapter3/Chapter3-Fundamentals-of-Large-Language-Models.md`

## English Summary

Reference [11] in Chapter 3 mixed the author list of Ji et al. (arXiv:2202.03629) with the title of Huang et al. (arXiv:2311.05232). This PR repoints [11] to Huang et al., matching how the citation is actually used in the text. Both Chinese and English versions are updated.
