### PR TITLE
fix(docs)：修正8.2.2和8.2.3中的memory_tool的run方法传入参数格式问题

### DIFF
--- a/docs/chapter8/Chapter8-Memory-and-Retrieval.md
+++ b/docs/chapter8/Chapter8-Memory-and-Retrieval.md
@@ -340,25 +340,44 @@ agent.tool_registry = tool_registry
 print("=== Adding Multiple Memories ===")
 
 # Add first memory
-result1 = memory_tool.execute("add", content="User Zhang San is a Python developer focusing on machine learning and data analysis", memory_type="semantic", importance=0.8)
+result1 = memory_tool.run({
+    "action": "add",
+    "content": "User Zhang San is a Python developer focusing on machine learning and data analysis",
+    "memory_type": "semantic",
+    "importance": 0.8
+})
 print(f"Memory 1: {result1}")
 
 # Add second memory
-result2 = memory_tool.execute("add", content="Li Si is a frontend engineer skilled in React and Vue.js development", memory_type="semantic", importance=0.7)
+result2 = memory_tool.run({
+    "action": "add",
+    "content": "Li Si is a frontend engineer skilled in React and Vue.js development",
+    "memory_type": "semantic",
+    "importance": 0.7
+})
 print(f"Memory 2: {result2}")
 
 # Add third memory
-result3 = memory_tool.execute("add", content="Wang Wu is a product manager responsible for user experience design and requirements analysis", memory_type="semantic", importance=0.6)
+result3 = memory_tool.run({
+    "action": "add",
+    "content": "Wang Wu is a product manager responsible for user experience design and requirements analysis",
+    "memory_type": "semantic",
+    "importance": 0.6
+})
 print(f"Memory 3: {result3}")
 
 print("\n=== Searching Specific Memories ===")
 # Search for frontend-related memories
 print("🔍 Searching 'frontend engineer':")
-result = memory_tool.execute("search", query="frontend engineer", limit=3)
+result = memory_tool.run({
+    "action": "search",
+    "query": "frontend engineer",
+    "limit": 3
+})
 print(result)
 
 print("\n=== Memory Summary ===")
-result = memory_tool.execute("summary")
+result = memory_tool.run({"action": "summary"})
 print(result)
 ```
 
@@ -445,37 +464,41 @@ For each memory type, we provide different usage examples:
 
 ```python
 # 1. Working Memory - Temporary information, limited capacity
-memory_tool.execute("add",
-    content="User just asked a question about Python functions",
-    memory_type="working",
-    importance=0.6
-)
+memory_tool.run({
+    "action": "add",
+    "content": "User just asked a question about Python functions",
+    "memory_type": "working",
+    "importance": 0.6
+})
 
 # 2. Episodic Memory - Specific events and experiences
-memory_tool.execute("add",
-    content="On March 15, 2024, user Zhang San completed their first Python project",
-    memory_type="episodic",
-    importance=0.8,
-    event_type="milestone",
-    location="Online learning platform"
-)
+memory_tool.run({
+    "action": "add",
+    "content": "On March 15, 2024, user Zhang San completed their first Python project",
+    "memory_type": "episodic",
+    "importance": 0.8,
+    "event_type": "milestone",
+    "location": "Online learning platform"
+})
 
 # 3. Semantic Memory - Abstract knowledge and concepts
-memory_tool.execute("add",
-    content="Python is an interpreted, object-oriented programming language",
-    memory_type="semantic",
-    importance=0.9,
-    knowledge_type="factual"
-)
+memory_tool.run({
+    "action": "add",
+    "content": "Python is an interpreted, object-oriented programming language",
+    "memory_type": "semantic",
+    "importance": 0.9,
+    "knowledge_type": "factual"
+})
 
 # 4. Perceptual Memory - Multimodal information
-memory_tool.execute("add",
-    content="User uploaded a Python code screenshot containing function definitions",
-    memory_type="perceptual",
-    importance=0.7,
-    modality="image",
-    file_path="./uploads/code_screenshot.png"
-)
+memory_tool.run({
+    "action": "add",
+    "content": "User uploaded a Python code screenshot containing function definitions",
+    "memory_type": "perceptual",
+    "importance": 0.7,
+    "modality": "image",
+    "file_path": "./uploads/code_screenshot.png"
+})
 ```
 
 (2) Operation 2: search

--- a/docs/chapter8/第八章 记忆与检索.md
+++ b/docs/chapter8/第八章 记忆与检索.md
@@ -341,25 +341,44 @@ agent.tool_registry = tool_registry
 print("=== 添加多个记忆 ===")
 
 # 添加第一个记忆
-result1 = memory_tool.execute("add", content="用户张三是一名Python开发者，专注于机器学习和数据分析", memory_type="semantic", importance=0.8)
+result1 = memory_tool.run({
+    "action": "add",
+    "content": "用户张三是一名Python开发者，专注于机器学习和数据分析",
+    "memory_type": "semantic",
+    "importance": 0.8
+})
 print(f"记忆1: {result1}")
 
 # 添加第二个记忆
-result2 = memory_tool.execute("add", content="李四是前端工程师，擅长React和Vue.js开发", memory_type="semantic", importance=0.7)
+result2 = memory_tool.run({
+    "action": "add",
+    "content": "李四是前端工程师，擅长React和Vue.js开发",
+    "memory_type": "semantic",
+    "importance": 0.7
+})
 print(f"记忆2: {result2}")
 
 # 添加第三个记忆
-result3 = memory_tool.execute("add", content="王五是产品经理，负责用户体验设计和需求分析", memory_type="semantic", importance=0.6)
+result3 = memory_tool.run({
+    "action": "add",
+    "content": "王五是产品经理，负责用户体验设计和需求分析",
+    "memory_type": "semantic",
+    "importance": 0.6
+})
 print(f"记忆3: {result3}")
 
 print("\n=== 搜索特定记忆 ===")
 # 搜索前端相关的记忆
 print("🔍 搜索 '前端工程师':")
-result = memory_tool.execute("search", query="前端工程师", limit=3)
+result = memory_tool.run({
+    "action": "search",
+    "query": "前端工程师",
+    "limit": 3
+})
 print(result)
 
 print("\n=== 记忆摘要 ===")
-result = memory_tool.execute("summary")
+result = memory_tool.run({"action":"summary"})
 print(result)
 ```
 
@@ -446,37 +465,41 @@ def _add_memory(
 
 ```python
 # 1. 工作记忆 - 临时信息，容量有限
-memory_tool.execute("add",
-    content="用户刚才问了关于Python函数的问题",
-    memory_type="working",
-    importance=0.6
-)
+memory_tool.run({
+    "action": "add",
+    "content": "用户刚才问了关于Python函数的问题",
+    "memory_type": "working",
+    "importance": 0.6
+})
 
 # 2. 情景记忆 - 具体事件和经历
-memory_tool.execute("add",
-    content="2024年3月15日，用户张三完成了第一个Python项目",
-    memory_type="episodic",
-    importance=0.8,
-    event_type="milestone",
-    location="在线学习平台"
-)
+memory_tool.run({
+    "action": "add",
+    "content": "2024年3月15日，用户张三完成了第一个Python项目",
+    "memory_type": "episodic",
+    "importance": 0.8,
+    "event_type": "milestone",
+    "location": "在线学习平台"
+})
 
 # 3. 语义记忆 - 抽象知识和概念
-memory_tool.execute("add",
-    content="Python是一种解释型、面向对象的编程语言",
-    memory_type="semantic",
-    importance=0.9,
-    knowledge_type="factual"
-)
+memory_tool.run({
+    "action": "add",
+    "content": "Python是一种解释型、面向对象的编程语言",
+    "memory_type": "semantic",
+    "importance": 0.9,
+    "knowledge_type": "factual"
+})
 
 # 4. 感知记忆 - 多模态信息
-memory_tool.execute("add",
-    content="用户上传了一张Python代码截图，包含函数定义",
-    memory_type="perceptual",
-    importance=0.7,
-    modality="image",
-    file_path="./uploads/code_screenshot.png"
-)
+memory_tool.run({
+    "action": "add",
+    "content": "用户上传了一张Python代码截图，包含函数定义",
+    "memory_type": "perceptual",
+    "importance": 0.7,
+    "modality": "image",
+    "file_path": "./uploads/code_screenshot.png"
+})
 ```
 
 （2）操作2：search


### PR DESCRIPTION

<img width="547" height="386" alt="Snipaste_2026-08-06_16-12-55" src="https://github.com/user-attachments/assets/f35f7cfa-7bfe-41ab-ac32-730fb818f610" />

### **问题**
第8章中8.2.2的“快速体验”以及8.2.3的”各个记忆类型的使用“示例代码中，`MemoryTool`调用`run`方法但传入参数格式不对，导致运行报错：
- `run`方法接受的参数传入格式应为字典格式，实际传入为多参数。

### **修改**
将第8章“快速体验”以及”各个记忆类型的使用“示例代码中`run`方法的参数统一修改为字典格式
中英文两版同步修正：
- `docs/chapter8/第八章 记忆与检索.md`
- `docs/chapter8/Chapter8-Memory-and-Retrieval.md`
