### PR TITLE
fix: add stream_think() to HelloAgentsLLM, use it in chapter7 stream_run

### DIFF
--- a/code/chapter4/llm_client.py
+++ b/code/chapter4/llm_client.py
@@ -1,7 +1,7 @@
 import os
 from openai import OpenAI
 from dotenv import load_dotenv
-from typing import List, Dict
+from typing import List, Dict, Iterator
 
 # 加载 .env 文件中的环境变量
 load_dotenv()
@@ -53,6 +53,29 @@ class HelloAgentsLLM:
         except Exception as e:
             print(f"❌ 调用LLM API时发生错误: {e}")
             return None
+
+    def stream_think(self, messages: List[Dict[str, str]], temperature: float = 0) -> Iterator[str]:
+        """
+        以生成器方式流式返回模型响应，每个 yield 是一段 delta.content。
+        不主动打印，由调用方决定如何展示。
+        """
+        print(f"🧠 正在调用 {self.model} 模型...")
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                temperature=temperature,
+                stream=True,
+            )
+            for chunk in response:
+                if not chunk.choices:
+                    continue
+                content = chunk.choices[0].delta.content
+                if not content:
+                    continue
+                yield content
+        except Exception as e:
+            print(f"❌ 调用LLM API时发生错误: {e}")
 
 # --- 客户端使用示例 ---
 if __name__ == '__main__':

--- a/code/chapter7/my_simple_agent.py
+++ b/code/chapter7/my_simple_agent.py
@@ -212,7 +212,7 @@ class MySimpleAgent(SimpleAgent):
         # 流式调用LLM
         full_response = ""
         print("📝 实时响应: ", end="")
-        for chunk in self.llm.stream_invoke(messages, **kwargs):
+        for chunk in self.llm.stream_think(messages, **kwargs):
             full_response += chunk
             print(chunk, end="", flush=True)
             yield chunk


### PR DESCRIPTION
修了 Chapter 7.5.2 流式输出重复的两个根因：

1. code/chapter7/my_simple_agent.py 的 stream_run 调 self.llm.stream_invoke(...) —— 这个方法在 HelloAgentsLLM 上根本不存在，照教程抄一遍直接 AttributeError。

2. code/chapter4/llm_client.py 的 think() 内部已经 print 过一遍，返回值是字符串。退而求其次迭代 llm.think(...) 的返回值会被当成字符序列逐个迭代，每个字符又被外层 print 一次 → 「根据根据」「计算计算」「结果是结果是」这种重复。code/chapter7/my_main.py 那句注释 "chunk 在 my_llm 库中已经打印过一遍，这里只需要 pass 即可" 就是这个别扭的 workaround。

改法：
- code/chapter4/llm_client.py 加一个 stream_think() 生成器（纯 yield，不打印），从 typing 引入 Iterator。
- code/chapter7/my_simple_agent.py 把不存在的 stream_invoke 换成 stream_think；外层 print(chunk, end="", flush=True) 保留，由调用方决定何时打印。

think() 旧行为保留，向后兼容，旧调用方不受影响。

Fixes #464