### PR TITLE
fix(ch4): parse answer_box_list objects

### DIFF
--- a/code/chapter4/test_tools.py
+++ b/code/chapter4/test_tools.py
@@ -1,8 +1,9 @@
+import importlib
 import os
 import sys
 import types
 import unittest
-
+from typing import ClassVar
 
 dotenv = types.ModuleType("dotenv")
 dotenv.load_dotenv = lambda: None
@@ -10,7 +11,7 @@ sys.modules["dotenv"] = dotenv
 
 
 class FakeSerpApiClient:
-    response = {}
+    response: ClassVar[dict] = {}
 
     def __init__(self, params):
         self.params = params
@@ -23,7 +24,7 @@ serpapi = types.ModuleType("serpapi")
 serpapi.SerpApiClient = FakeSerpApiClient
 sys.modules["serpapi"] = serpapi
 
-from tools import search  # noqa: E402
+search = importlib.import_module("tools").search
 
 
 class SearchAnswerBoxListTest(unittest.TestCase):

--- a/code/chapter4/test_tools.py
+++ b/code/chapter4/test_tools.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+import unittest
+
+
+dotenv = types.ModuleType("dotenv")
+dotenv.load_dotenv = lambda: None
+sys.modules["dotenv"] = dotenv
+
+
+class FakeSerpApiClient:
+    response = {}
+
+    def __init__(self, params):
+        self.params = params
+
+    def get_dict(self):
+        return self.response
+
+
+serpapi = types.ModuleType("serpapi")
+serpapi.SerpApiClient = FakeSerpApiClient
+sys.modules["serpapi"] = serpapi
+
+from tools import search  # noqa: E402
+
+
+class SearchAnswerBoxListTest(unittest.TestCase):
+    def setUp(self):
+        os.environ["SERPAPI_API_KEY"] = "test-key"
+
+    def tearDown(self):
+        os.environ.pop("SERPAPI_API_KEY", None)
+
+    def test_extracts_answers_from_answer_box_objects(self):
+        FakeSerpApiClient.response = {
+            "answer_box_list": [
+                {"answer": "first answer"},
+                {"answer": "second answer"},
+            ]
+        }
+
+        self.assertEqual(search("query"), "first answer\nsecond answer")
+
+    def test_falls_back_when_list_has_no_text_answer(self):
+        FakeSerpApiClient.response = {
+            "answer_box_list": [{"title": "answer without text"}, None],
+            "answer_box": {"answer": "fallback answer"},
+        }
+
+        self.assertEqual(search("query"), "fallback answer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/chapter4/tools.py
+++ b/code/chapter4/tools.py
@@ -30,7 +30,15 @@ def search(query: str) -> str:
         
         # 智能解析：优先寻找最直接的答案
         if "answer_box_list" in results:
-            return "\n".join(results["answer_box_list"])
+            answers = [
+                box["answer"]
+                for box in results["answer_box_list"]
+                if isinstance(box, dict)
+                and isinstance(box.get("answer"), str)
+                and box["answer"]
+            ]
+            if answers:
+                return "\n".join(answers)
         if "answer_box" in results and "answer" in results["answer_box"]:
             return results["answer_box"]["answer"]
         if "knowledge_graph" in results and "description" in results["knowledge_graph"]:

--- a/docs/chapter4/Chapter4-Building-Classic-Agent-Paradigms.md
+++ b/docs/chapter4/Chapter4-Building-Classic-Agent-Paradigms.md
@@ -231,7 +231,15 @@ def search(query: str) -> str:
         
         # Intelligent parsing: prioritize finding the most direct answer
         if "answer_box_list" in results:
-            return "\n".join(results["answer_box_list"])
+            answers = [
+                box["answer"]
+                for box in results["answer_box_list"]
+                if isinstance(box, dict)
+                and isinstance(box.get("answer"), str)
+                and box["answer"]
+            ]
+            if answers:
+                return "\n".join(answers)
         if "answer_box" in results and "answer" in results["answer_box"]:
             return results["answer_box"]["answer"]
         if "knowledge_graph" in results and "description" in results["knowledge_graph"]:
@@ -250,7 +258,7 @@ def search(query: str) -> str:
         return f"Error occurred during search: {e}"
 ```
 
-In the above code, it first checks whether `answer_box` (Google's answer summary box) or `knowledge_graph` (knowledge graph) information exists. If it does, it directly returns these most precise answers. If not, it falls back to returning summaries of the first three regular search results. This "intelligent parsing" can provide higher-quality information input for the LLM.
+In the code above, it first checks for `answer_box_list` or `answer_box` (Google answer boxes), as well as `knowledge_graph` information. Because `answer_box_list` contains answer-box objects, the code extracts each non-empty `answer` field before joining the text. If the list has no usable answer, it continues to the other result types instead of returning an empty string. Only when none of these direct sources is available does it fall back to summaries of the first three organic results. This "intelligent parsing" can provide higher-quality information input for the LLM.
 
 (2) Building a General Tool Executor
 
@@ -1307,4 +1315,3 @@ At this point, we have mastered the core technologies for building individual ag
 [2] Wang L, Xu W, Lan Y, et al. Plan-and-solve prompting: Improving zero-shot chain-of-thought reasoning by large language models[J]. arXiv preprint arXiv:2305.04091, 2023.
 
 [3] Shinn N, Cassano F, Gopinath A, et al. Reflexion: Language agents with verbal reinforcement learning[J]. Advances in Neural Information Processing Systems, 2023, 36: 8634-8652.
-

--- a/docs/chapter4/第四章 智能体经典范式构建.md
+++ b/docs/chapter4/第四章 智能体经典范式构建.md
@@ -231,7 +231,15 @@ def search(query: str) -> str:
         
         # 智能解析:优先寻找最直接的答案
         if "answer_box_list" in results:
-            return "\n".join(results["answer_box_list"])
+            answers = [
+                box["answer"]
+                for box in results["answer_box_list"]
+                if isinstance(box, dict)
+                and isinstance(box.get("answer"), str)
+                and box["answer"]
+            ]
+            if answers:
+                return "\n".join(answers)
         if "answer_box" in results and "answer" in results["answer_box"]:
             return results["answer_box"]["answer"]
         if "knowledge_graph" in results and "description" in results["knowledge_graph"]:
@@ -250,7 +258,7 @@ def search(query: str) -> str:
         return f"搜索时发生错误: {e}"
 ```
 
-在上述代码中，首先会检查是否存在 `answer_box`（Google的答案摘要框）或 `knowledge_graph`（知识图谱）等信息，如果存在，就直接返回这些最精确的答案。如果不存在，它才会退而求其次，返回前三个常规搜索结果的摘要。这种“智能解析”能为LLM提供质量更高的信息输入。
+在上述代码中，首先会检查是否存在 `answer_box_list` 或 `answer_box`（Google 的答案摘要框）以及 `knowledge_graph`（知识图谱）等信息。`answer_box_list` 是由答案框对象组成的列表，因此需要先从每个对象中提取非空的 `answer` 字段，再拼接为文本；如果列表中没有可用答案，代码会继续尝试其他结果，而不是提前返回空字符串。都不存在时，它才会退而求其次，返回前三个常规搜索结果的摘要。这种“智能解析”能为 LLM 提供质量更高的信息输入。
 
 （2）构建通用的工具执行器
 


### PR DESCRIPTION
## 问题

`answer_box_list` 是答案框对象列表。当前代码直接执行
`"\n".join(results["answer_box_list"])`，当列表元素为字典时会触发：

```text
sequence item 0: expected str instance, dict found
```

这会让 `search()` 捕获异常并把错误文本返回给 Agent，而不是返回搜索答案。

Refs #849

## 改动

- 从每个答案框对象提取非空字符串 `answer` 后再拼接。
- 当列表中没有可用 `answer` 时继续尝试单个 `answer_box`、知识图谱和自然结果，避免提前返回空字符串。
- 同步中文、英文教程中的代码与行为说明。
- 新增无网络定向测试，覆盖多个答案框对象和回退路径。

SerpApi 官方资料说明多答案通过 `answer_box_list` 数组返回：
https://serpapi.com/direct-answer-box-api

## 验证

```bash
python3 -m unittest discover -s code/chapter4 -p 'test_*.py' -v
# Ran 2 tests ... OK

python3 -m py_compile code/chapter4/tools.py code/chapter4/test_tools.py
ruff check code/chapter4/test_tools.py
git diff --check
```

另外按教程依赖安装 `google-search-results==2.4.2`，使用真实
`SerpApiClient` 类并仅 mock `get_dict()` 的网络结果完成 smoke test，
确认两个答案输出为 `first\nsecond`。未使用真实 API key，也未发起外部
SerpApi 请求。

## 竞争与范围

- 创建前检查了 #849 时间线、开放/历史 PR、`answer_box_list` 符号和近期提交，未发现同主题实现。
- #676 和 #746 修改 SerpApi SDK/依赖，但都保留原有 `join(dict)` 逻辑；本 PR 不改变 SDK 选择或依赖版本。
- 改动仅限 Chapter 4 的配套代码、双语正文和定向测试。
