### PR TITLE
docs(chapter12): correct BFCL matching semantics

### DIFF
--- a/docs/chapter12/Chapter12-Agent-Performance-Evaluation.md
+++ b/docs/chapter12/Chapter12-Agent-Performance-Evaluation.md
@@ -224,37 +224,35 @@ The BFCL dataset uses JSON format, with each test sample containing the followin
 - `function`: List of available functions (including function signatures and descriptions)
 - `ground_truth`: Standard answer (expected function call)
 
-**(2) AST Matching Explanation**
+**(2) Function Call Matching**
 
-BFCL uses **AST Matching (Abstract Syntax Tree Matching)** as the core evaluation algorithm, so let's understand the evaluation strategy below.
+BFCL parses model output into structured function calls, then validates function names, parameter types, and parameter values instead of comparing raw strings. The BFCL v4 path in HelloAgents `0.2.3` likewise compares parsed argument dictionaries by key, so keyword argument order does not affect the result.
 
-BFCL uses Abstract Syntax Tree (AST) for intelligent matching, rather than simple string matching. The core idea of AST matching is: **Parse function calls into syntax trees, then compare tree structure and node values**.
-
-Given predicted function call $P$ and standard answer $G$, the AST matching function is defined as:
+Given a predicted function call $P$ and ground truth $G$, the matching condition can be summarized as:
 
 $$
-\text{AST\_Match}(P, G) = \begin{cases}
-1 & \text{if } \text{AST}(P) \equiv \text{AST}(G) \\
+\text{Match}(P, G) = \begin{cases}
+1 & \text{if } \text{Name}(P) = \text{Name}(G) \land \text{Args}(P) \models \text{Args}(G) \\
 0 & \text{otherwise}
 \end{cases}
 $$
 
-Where $\text{AST}(x)$ represents parsing function call into abstract syntax tree, $\equiv$ represents syntax tree equivalence.
+Here, $\text{Args}(P) \models \text{Args}(G)$ means that the predicted arguments satisfy the names, types, and acceptable values specified by the ground truth.
 
-Two syntax trees are equivalent if they satisfy three core conditions: function names must be completely identical (exact match), parameter key-value pair sets are equal (ignoring order), and each parameter value is semantically equivalent (e.g., `2+3` is equivalent to `5`). In the specific matching process, function name matching requires exact string matching, for example `get_weather` and `get_temperature` are considered different functions. Parameter matching uses AST for intelligent comparison, allowing different parameter orders (`f(a=1, b=2)` is equivalent to `f(b=2, a=1)`), allowing equivalent expressions (`f(x=2+3)` is equivalent to `f(x=5)`), and also allowing different string representations (`f(s="hello")` is equivalent to `f(s='hello')`). For multi-function call scenarios, the matching algorithm requires calling the same number of functions, each function call must match, but call order can differ (using set matching).
+Structured argument matching must not be confused with Python AST structure comparison. Because arguments are looked up by key, `f(a=1, b=2)` and `f(b=2, a=1)` can match on the BFCL v4 path. However, `ast.dump()` compares syntax-tree structure and does not evaluate arbitrary expressions, so `f(x=2+3)` and `f(x=5)` do not match. The legacy string-format fallback in HelloAgents `0.2.3` directly compares `ast.dump()` output and does not normalize keyword order either. An evaluator should not use `eval()` to execute model-generated expressions.
 
-**AST Matching Examples:**
+**Matching Examples:**
 
 ```python
-# Example 1: Different parameter order (match successful)
+# Example 1: Different parameter order (BFCL v4 argument dictionaries match)
 Prediction: get_weather(city="Beijing", unit="celsius")
 Standard: get_weather(unit="celsius", city="Beijing")
 Result: ✅ Match successful
 
-# Example 2: Equivalent expression (match successful)
+# Example 2: Different syntax structure (expressions are not evaluated)
 Prediction: calculate(x=2+3)
 Standard: calculate(x=5)
-Result: ✅ Match successful
+Result: ❌ Match failed
 
 # Example 3: Wrong function name (match failed)
 Prediction: get_temperature(city="Beijing")
@@ -833,36 +831,31 @@ class BFCLMetrics:
         }
 ````
 
-**AST Matching Implementation**:
+**BFCL v4 Argument Matching Implementation**:
 
-AST matching is the core technology of BFCL evaluation. It is more intelligent than simple string matching and can identify semantically equivalent function calls:
+The BFCL v4 path in HelloAgents `0.2.3` looks up each predicted value by parameter name and checks it against the acceptable values in the ground truth. This behavior can be verified in the [HelloAgents V0.2.3 evaluator source](https://github.com/jjyaoao/HelloAgents/blob/9a1af1bf968f8cd1974da227ce8782857d1afee8/hello_agents/evaluation/benchmarks/bfcl/evaluator.py). The official BFCL evaluator additionally validates types and values against the function schema; see BFCL's [`ast_checker.py`](https://github.com/ShishirPatil/gorilla/blob/6ea57973c7a6097fd7c5915698c54c17c5b1b6c8/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/ast_eval/ast_checker.py). The relevant HelloAgents core logic is shown below. Because the arguments are dictionaries, insertion order is irrelevant, and expressions inside predicted values are never executed:
 
 ```python
-def _ast_match(self, pred_call: Dict, true_call: Dict) -> bool:
-    """Match function calls using AST
+def _compare_parameters(self, pred_params: Dict, exp_params: Dict) -> bool:
+    """Compare predicted arguments with acceptable BFCL v4 values."""
+    for param_name, expected_values in exp_params.items():
+        if param_name not in pred_params:
+            if not isinstance(expected_values, list) or "" not in expected_values:
+                return False
+            continue
 
-    Advantages of AST matching:
-    1. Ignore parameter order: func(a=1, b=2) equivalent to func(b=2, a=1)
-    2. Recognize equivalent expressions: 2+3 equivalent to 5
-    3. Ignore whitespace and format differences
-    """
-    # 1. Function name must match exactly
-    if pred_call.get("name") != true_call.get("name"):
-        return False
+        pred_value = pred_params[param_name]
+        if isinstance(expected_values, list):
+            if pred_value not in expected_values:
+                if str(pred_value) not in [str(v) for v in expected_values]:
+                    return False
+        elif (
+            pred_value != expected_values
+            and str(pred_value) != str(expected_values)
+        ):
+            return False
 
-    # 2. Convert parameters to AST nodes
-    pred_args = self._args_to_ast(pred_call.get("arguments", {}))
-    true_args = self._args_to_ast(true_call.get("arguments", {}))
-
-    # 3. Compare AST nodes
-    return ast.dump(pred_args) == ast.dump(true_args)
-
-def _args_to_ast(self, args: Dict[str, Any]) -> ast.AST:
-    """Convert parameter dictionary to AST node"""
-    # Construct a virtual function call
-    code = f"func({', '.join(f'{k}={repr(v)}' for k, v in args.items())})"
-    tree = ast.parse(code)
-    return tree.body[0].value  # Return Call node
+    return True
 ```
 
 **(4) Tool Encapsulation: BFCLEvaluationTool**
@@ -2684,7 +2677,7 @@ We established a three-tier evaluation system, comprehensively covering differen
 
 **(2) Core Technical Points**
 
-In technical implementation, we adopted six core technical points. First is modular design, evaluation system adopts three-tier architecture: data layer (Dataset responsible for data loading and management), evaluation layer (Evaluator responsible for executing evaluation flow), and metrics layer (Metrics responsible for calculating various evaluation metrics). Second is tool encapsulation, all evaluation functions are encapsulated as Tools, can be directly called by agents, integrated into workflows, or used through unified interface. Third is AST matching technology, using abstract syntax tree matching for function calls, more intelligent than simple string matching, able to ignore parameter order, recognize equivalent expressions, and ignore format differences. Fourth is multimodal support, GAIA evaluation supports text questions, attachment files, image inputs and other multimodal data. Fifth is LLM Judge evaluation, using LLM as judge to evaluate generated data quality, providing multi-dimensional scoring (correctness, clarity, difficulty matching, completeness), automated evaluation flow, detailed evaluation reports, and supporting custom evaluation dimensions and standards. Sixth is Win Rate comparison evaluation, evaluating generation quality through pairwise comparison (generated data vs reference data), LLM judges which is better and calculates win rate statistics, close to 50% indicates equivalent quality.
+In technical implementation, we adopted six core technical points. First is modular design, evaluation system adopts three-tier architecture: data layer (Dataset responsible for data loading and management), evaluation layer (Evaluator responsible for executing evaluation flow), and metrics layer (Metrics responsible for calculating various evaluation metrics). Second is tool encapsulation, all evaluation functions are encapsulated as Tools, can be directly called by agents, integrated into workflows, or used through unified interface. Third is structured function-call matching, which parses model output and validates function names, parameter types, and acceptable values. The BFCL v4 argument-dictionary path is insensitive to keyword argument order but does not execute arbitrary expressions. Fourth is multimodal support, GAIA evaluation supports text questions, attachment files, image inputs and other multimodal data. Fifth is LLM Judge evaluation, using LLM as judge to evaluate generated data quality, providing multi-dimensional scoring (correctness, clarity, difficulty matching, completeness), automated evaluation flow, detailed evaluation reports, and supporting custom evaluation dimensions and standards. Sixth is Win Rate comparison evaluation, evaluating generation quality through pairwise comparison (generated data vs reference data), LLM judges which is better and calculates win rate statistics, close to 50% indicates equivalent quality.
 
 **(3) Extension Directions**
 
@@ -2759,4 +2752,3 @@ In the next chapter, we will explore how to apply the HelloAgents framework to a
 [8] Zhou, X., Zhu, H., Mathur, L., Zhang, R., Yu, H., Qi, Z., ... & Neubig, G. (2023). SOTOPIA: Interactive Evaluation for Social Intelligence in Language Agents. arXiv preprint arXiv:2310.11667.
 
 [9] Mathematical Association of America. (2024). American Invitational Mathematics Examination (AIME). Retrieved from https://www.maa.org/math-competitions/invitational-competitions/aime
-

--- a/docs/chapter12/第十二章 智能体性能评估.md
+++ b/docs/chapter12/第十二章 智能体性能评估.md
@@ -222,37 +222,35 @@ BFCL 数据集采用 JSON 格式，每个测试样本包含以下字段：
 - `function`: 可用的函数列表（包含函数签名和描述）
 - `ground_truth`: 标准答案（期望的函数调用）
 
-<strong>（2）AST 匹配说明</strong>
+<strong>（2）函数调用匹配说明</strong>
 
-BFCL 使用<strong>AST 匹配（Abstract Syntax Tree Matching）</strong>作为核心评估算法，因此下文可以了解一下评估的策略。
+BFCL 将模型输出解析为结构化函数调用，再校验函数名、参数类型和参数值，而不是直接比较原始字符串。HelloAgents `0.2.3` 的 BFCL v4 评估路径同样使用解析后的参数字典逐项匹配，因此关键字参数的书写顺序不影响结果。
 
-BFCL 使用抽象语法树（AST）进行智能匹配，而不是简单的字符串匹配。AST 匹配的核心思想是：<strong>将函数调用解析为语法树，然后比较树的结构和节点值</strong>。
-
-给定预测的函数调用 $P$ 和标准答案 $G$，AST 匹配函数定义为：
+给定预测的函数调用 $P$ 和标准答案 $G$，可以将匹配条件概括为：
 
 $$
-\text{AST\_Match}(P, G) = \begin{cases}
-1 & \text{if } \text{AST}(P) \equiv \text{AST}(G) \\
+\text{Match}(P, G) = \begin{cases}
+1 & \text{if } \text{Name}(P) = \text{Name}(G) \land \text{Args}(P) \models \text{Args}(G) \\
 0 & \text{otherwise}
 \end{cases}
 $$
 
-其中 $\text{AST}(x)$ 表示将函数调用解析为抽象语法树，$\equiv$ 表示语法树等价。
+其中 $\text{Args}(P) \models \text{Args}(G)$ 表示预测参数满足标准答案规定的参数名、类型和可接受值。
 
-两个语法树等价需要满足三个核心条件：函数名必须完全一致（精确匹配），参数键值对集合相等（忽略顺序），以及每个参数的值在语义上等价（例如 `2+3` 等价于 `5`）。在具体的匹配过程中，函数名匹配要求字符串精确匹配，例如 `get_weather` 和 `get_temperature` 被视为不同的函数。参数匹配则使用 AST 进行智能比较，允许参数顺序不同（`f(a=1, b=2)` 等价于 `f(b=2, a=1)`），允许等价表达式（`f(x=2+3)` 等价于 `f(x=5)`），也允许不同的字符串表示（`f(s="hello")` 等价于 `f(s='hello')`）。对于多函数调用的场景，匹配算法要求调用相同数量的函数，每个函数调用都必须匹配，但调用顺序可以不同（使用集合匹配）。
+需要区分“结构化参数匹配”和 Python AST 结构比较。参数字典按键查询，所以 `f(a=1, b=2)` 与 `f(b=2, a=1)` 在 BFCL v4 路径中可以匹配；但 `ast.dump()` 只比较语法树结构，不会自动计算任意表达式，因此 `f(x=2+3)` 与 `f(x=5)` 不匹配。HelloAgents `0.2.3` 的旧字符串格式回退路径直接比较 `ast.dump()`，连关键字参数顺序也不会归一化。评估不应通过 `eval()` 执行模型生成的表达式。
 
-<strong>AST 匹配示例：</strong>
+<strong>匹配示例：</strong>
 
 ```python
-# 示例1：参数顺序不同（匹配成功）
+# 示例1：参数顺序不同（BFCL v4 参数字典匹配成功）
 预测: get_weather(city="Beijing", unit="celsius")
 标准: get_weather(unit="celsius", city="Beijing")
 结果: ✅ 匹配成功
 
-# 示例2：等价表达式（匹配成功）
+# 示例2：语法结构不同（不进行表达式求值）
 预测: calculate(x=2+3)
 标准: calculate(x=5)
-结果: ✅ 匹配成功
+结果: ❌ 匹配失败
 
 # 示例3：函数名错误（匹配失败）
 预测: get_temperature(city="Beijing")
@@ -827,36 +825,31 @@ class BFCLMetrics:
             "category_statistics": self._compute_category_stats(results)
         }
 ````
-<strong>AST 匹配的实现</strong>：
+<strong>BFCL v4 参数匹配的实现</strong>：
 
-AST 匹配是 BFCL 评估的核心技术。它比简单的字符串匹配更智能，能够识别语义等价的函数调用：
+HelloAgents `0.2.3` 的 BFCL v4 路径按参数名查询预测值，并检查它是否属于标准答案给出的可接受值列表。该行为可在 [HelloAgents V0.2.3 的评估器源码](https://github.com/jjyaoao/HelloAgents/blob/9a1af1bf968f8cd1974da227ce8782857d1afee8/hello_agents/evaluation/benchmarks/bfcl/evaluator.py) 中核对；BFCL 官方评估器还会结合函数 schema 校验类型与取值，详见 [BFCL 官方 `ast_checker.py`](https://github.com/ShishirPatil/gorilla/blob/6ea57973c7a6097fd7c5915698c54c17c5b1b6c8/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/ast_eval/ast_checker.py)。下面保留与本节相关的 HelloAgents 核心逻辑；由于参数是字典，比较不依赖插入顺序，也不会执行预测值中的表达式：
 
 ```python
-def _ast_match(self, pred_call: Dict, true_call: Dict) -> bool:
-    """使用AST匹配函数调用
+def _compare_parameters(self, pred_params: Dict, exp_params: Dict) -> bool:
+    """比较预测参数和 BFCL v4 标准答案中的可接受值。"""
+    for param_name, expected_values in exp_params.items():
+        if param_name not in pred_params:
+            if not isinstance(expected_values, list) or "" not in expected_values:
+                return False
+            continue
 
-    AST匹配的优势：
-    1. 忽略参数顺序：func(a=1, b=2) 等价于 func(b=2, a=1)
-    2. 识别等价表达式：2+3 等价于 5
-    3. 忽略空格和格式差异
-    """
-    # 1. 函数名必须完全匹配
-    if pred_call.get("name") != true_call.get("name"):
-        return False
+        pred_value = pred_params[param_name]
+        if isinstance(expected_values, list):
+            if pred_value not in expected_values:
+                if str(pred_value) not in [str(v) for v in expected_values]:
+                    return False
+        elif (
+            pred_value != expected_values
+            and str(pred_value) != str(expected_values)
+        ):
+            return False
 
-    # 2. 将参数转换为AST节点
-    pred_args = self._args_to_ast(pred_call.get("arguments", {}))
-    true_args = self._args_to_ast(true_call.get("arguments", {}))
-
-    # 3. 比较AST节点
-    return ast.dump(pred_args) == ast.dump(true_args)
-
-def _args_to_ast(self, args: Dict[str, Any]) -> ast.AST:
-    """将参数字典转换为AST节点"""
-    # 构造一个虚拟的函数调用
-    code = f"func({', '.join(f'{k}={repr(v)}' for k, v in args.items())})"
-    tree = ast.parse(code)
-    return tree.body[0].value  # 返回Call节点
+    return True
 ```
 
 <strong>（4）工具化封装：BFCLEvaluationTool</strong>
@@ -2665,7 +2658,7 @@ python data_generation/run_complete_evaluation.py 30 3.0
 
 <strong>（2）核心技术要点</strong>
 
-在技术实现上，我们采用了六个核心技术要点。首先是模块化设计，评估系统采用三层架构：数据层（Dataset 负责数据加载和管理）、评估层（Evaluator 负责执行评估流程）和指标层（Metrics 负责计算各种评估指标）。其次是工具化封装，所有评估功能都封装成 Tool，可以被智能体直接调用、集成到工作流中或通过统一接口使用。第三是 AST 匹配技术，使用抽象语法树匹配函数调用，比简单字符串匹配更智能，能够忽略参数顺序、识别等价表达式和忽略格式差异。第四是多模态支持，GAIA 评估支持文本问题、附件文件和图片输入等多模态数据。第五是 LLM Judge 评估，使用 LLM 作为评委评估生成数据质量，提供多维度评分（正确性、清晰度、难度匹配、完整性）、自动化评估流程、详细评估报告，并支持自定义评估维度和标准。第六是 Win Rate 对比评估，通过成对对比评估生成质量（生成数据 vs 参考数据），由 LLM 判断哪个更好并计算胜率统计，接近 50%表示质量相当。
+在技术实现上，我们采用了六个核心技术要点。首先是模块化设计，评估系统采用三层架构：数据层（Dataset 负责数据加载和管理）、评估层（Evaluator 负责执行评估流程）和指标层（Metrics 负责计算各种评估指标）。其次是工具化封装，所有评估功能都封装成 Tool，可以被智能体直接调用、集成到工作流中或通过统一接口使用。第三是结构化函数调用匹配，解析模型输出后按函数名、参数类型和可接受值进行校验；BFCL v4 参数字典路径不受关键字参数书写顺序影响，但不会执行任意表达式。第四是多模态支持，GAIA 评估支持文本问题、附件文件和图片输入等多模态数据。第五是 LLM Judge 评估，使用 LLM 作为评委评估生成数据质量，提供多维度评分（正确性、清晰度、难度匹配、完整性）、自动化评估流程、详细评估报告，并支持自定义评估维度和标准。第六是 Win Rate 对比评估，通过成对对比评估生成质量（生成数据 vs 参考数据），由 LLM 判断哪个更好并计算胜率统计，接近 50%表示质量相当。
 
 <strong>（3）扩展方向</strong>
 
@@ -2740,4 +2733,3 @@ python data_generation/run_complete_evaluation.py 30 3.0
 [8] Zhou, X., Zhu, H., Mathur, L., Zhang, R., Yu, H., Qi, Z., ... & Neubig, G. (2023). SOTOPIA: Interactive Evaluation for Social Intelligence in Language Agents. arXiv preprint arXiv:2310.11667.
 
 [9] Mathematical Association of America. (2024). American Invitational Mathematics Examination (AIME). Retrieved from https://www.maa.org/math-competitions/invitational-competitions/aime
-


### PR DESCRIPTION
## 问题

第 12 章的中英文正文将两种不同机制混为一谈：

- 示例声称关键字参数换序后 `ast.dump()` 仍能匹配；
- 示例声称 `ast.dump()` 会将 `2+3` 与 `5` 判断为等价；
- 展示的 `_ast_match` / `_args_to_ast` 并不存在于教程固定的 `hello-agents==0.2.3` 中。

Issue #389 的最小复现确认两组裸 AST 比较都返回 `False`。

## 改动

- 将说明改为结构化函数调用匹配，明确 BFCL v4 参数字典路径按键比较，因此关键字顺序无关。
- 明确 `ast.dump()` 只比较语法结构，不会执行或化简任意表达式；将 `2+3` / `5` 示例修正为不匹配。
- 使用 `hello-agents==0.2.3` 中真实的 `_compare_parameters` 核心逻辑替换不存在的伪实现。
- 同步更新中英文正文和章节总结。
- 添加固定 commit 的 HelloAgents V0.2.3 与 BFCL 官方 checker 源码链接，便于复核。

## 验证

```bash
# Issue #389 最小复现
python3 -c 'import ast; assert ast.dump(ast.parse("calculate(x=2+3)", mode="eval")) != ast.dump(ast.parse("calculate(x=5)", mode="eval")); assert ast.dump(ast.parse("get_weather(city=\"Beijing\", unit=\"celsius\")", mode="eval")) != ast.dump(ast.parse("get_weather(unit=\"celsius\", city=\"Beijing\")", mode="eval"))'
# PASS

# 从 PyPI 安装固定版本 wheel（仅源码包，不解析额外依赖）
PACKAGE_DIR="$(mktemp -d)/hello-agents-0.2.3"
python3 -m pip install --target "$PACKAGE_DIR" hello-agents==0.2.3 --no-deps

# 对真实 BFCLEvaluator 验证 v4 与旧字符串路径
PYTHONPATH="$PACKAGE_DIR" python3 -c 'from hello_agents.evaluation import BFCLEvaluator; e=BFCLEvaluator.__new__(BFCLEvaluator); assert e._compare_parameters({"city":"Beijing","unit":"celsius"},{"unit":["celsius"],"city":["Beijing"]}); assert not e._compare_parameters({"x":"2+3"},{"x":[5]}); assert not e._ast_strings_match("get_weather(city=\"Beijing\", unit=\"celsius\")","get_weather(unit=\"celsius\", city=\"Beijing\")"); assert not e._ast_strings_match("calculate(x=2+3)","calculate(x=5)")'
# PASS（Python 3.10.20，hello-agents 0.2.3）

git diff --check
# PASS
```

同时通过 GitHub Contents API 读取并核对 PR 中固定 commit 对应的 HelloAgents evaluator 与 BFCL 官方 `ast_checker.py`；两个固定链接均可访问，文中对参数字典、AST 回退、schema 类型与取值检查的描述与源码一致。

## 竞争审计

- Issue #389 时间线唯一交叉引用为本 Draft PR，无 assignee、评论或其他关联实现。
- 精确搜索开放及历史 PR 的 `#389`、`ast.dump`、`BFCL`、`2+3` 和 `_compare_parameters`；同题结果仅为本 PR。
- 开放 PR #742 修改相同两份文件，但仅新增 ClawBench 概览与参考文献，补丁区间不重叠。
- 两份 Chapter 12 文档在主分支上的最近相关提交为 `78f4fe5`（GAIA 图注修正），未覆盖本问题。

Refs #389
