### PR TITLE
docs(chapter9): align ContextBuilder packet argument

### DIFF
--- a/docs/chapter9/Chapter9-Context-Engineering.md
+++ b/docs/chapter9/Chapter9-Context-Engineering.md
@@ -224,7 +224,7 @@ def _gather(
     user_query: str,
     conversation_history: Optional[List[Message]] = None,
     system_instructions: Optional[str] = None,
-    custom_packets: Optional[List[ContextPacket]] = None
+    additional_packets: Optional[List[ContextPacket]] = None
 ) -> List[ContextPacket]:
     """Collect all candidate information
 
@@ -232,7 +232,7 @@ def _gather(
         user_query: User query
         conversation_history: Conversation history
         system_instructions: System instructions
-        custom_packets: Custom information packages
+        additional_packets: Additional information packages
 
     Returns:
         List[ContextPacket]: Candidate information list
@@ -291,9 +291,9 @@ def _gather(
                 metadata={"type": "conversation_history", "role": msg.role}
             ))
 
-    # 5. Add custom information packages
-    if custom_packets:
-        packets.extend(custom_packets)
+    # 5. Add additional information packages
+    if additional_packets:
+        packets.extend(additional_packets)
 
     print(f"[ContextBuilder] Collected {len(packets)} candidate information packages")
     return packets
@@ -867,7 +867,7 @@ def run(self, user_input: str) -> str:
     # 3. Pass notes when building context
     context = self.context_builder.build(
         user_query=user_input,
-        custom_packets=note_packets,
+        additional_packets=note_packets,
         ...
     )
 ```
@@ -1364,7 +1364,7 @@ class ProjectAssistant(SimpleAgent):
             user_query=user_input,
             conversation_history=self.conversation_history,
             system_instructions=self._build_system_instructions(),
-            custom_packets=note_packets
+            additional_packets=note_packets
         )
 
         # 4. Call LLM
@@ -2017,7 +2017,7 @@ packets = [
 # Include this information when building context
 context = context_builder.build(
     user_query="How to refactor the user service module?",
-    custom_packets=packets
+    additional_packets=packets
 )
 ```
 
@@ -2146,7 +2146,7 @@ class CodebaseMaintainer:
             user_query=user_input,
             conversation_history=self.conversation_history,
             system_instructions=self._build_system_instructions(mode),
-            custom_packets=note_packets + pre_context
+            additional_packets=note_packets + pre_context
         )
 
         # Step 4: Call LLM
@@ -2809,4 +2809,3 @@ In the next chapter, we will explore agent communication protocols and learn how
 [1] Anthropic. Effective Context Engineering for AI Agents. `https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents`
 
 [2] David Kim. Context-Engineering (GitHub). `https://github.com/davidkimai/Context-Engineering`
-

--- a/docs/chapter9/第九章 上下文工程.md
+++ b/docs/chapter9/第九章 上下文工程.md
@@ -228,7 +228,7 @@ def _gather(
     user_query: str,
     conversation_history: Optional[List[Message]] = None,
     system_instructions: Optional[str] = None,
-    custom_packets: Optional[List[ContextPacket]] = None
+    additional_packets: Optional[List[ContextPacket]] = None
 ) -> List[ContextPacket]:
     """汇集所有候选信息
 
@@ -236,7 +236,7 @@ def _gather(
         user_query: 用户查询
         conversation_history: 对话历史
         system_instructions: 系统指令
-        custom_packets: 自定义信息包
+        additional_packets: 额外信息包
 
     Returns:
         List[ContextPacket]: 候选信息列表
@@ -295,9 +295,9 @@ def _gather(
                 metadata={"type": "conversation_history", "role": msg.role}
             ))
 
-    # 5. 添加自定义信息包
-    if custom_packets:
-        packets.extend(custom_packets)
+    # 5. 添加额外信息包
+    if additional_packets:
+        packets.extend(additional_packets)
 
     print(f"[ContextBuilder] 汇集了 {len(packets)} 个候选信息包")
     return packets
@@ -873,7 +873,7 @@ def run(self, user_input: str) -> str:
     # 3. 构建上下文时传入笔记
     context = self.context_builder.build(
         user_query=user_input,
-        custom_packets=note_packets,
+        additional_packets=note_packets,
         ...
     )
 ```
@@ -1370,7 +1370,7 @@ class ProjectAssistant(SimpleAgent):
             user_query=user_input,
             conversation_history=self.conversation_history,
             system_instructions=self._build_system_instructions(),
-            custom_packets=note_packets
+            additional_packets=note_packets
         )
 
         # 4. 调用 LLM
@@ -2023,7 +2023,7 @@ packets = [
 # 在构建上下文时包含这些信息
 context = context_builder.build(
     user_query="如何重构用户服务模块?",
-    custom_packets=packets
+    additional_packets=packets
 )
 ```
 
@@ -2153,7 +2153,7 @@ class CodebaseMaintainer:
             user_query=user_input,
             conversation_history=self.conversation_history,
             system_instructions=self._build_system_instructions(mode),
-            custom_packets=note_packets + pre_context
+            additional_packets=note_packets + pre_context
         )
 
         # 第四步:调用 LLM
@@ -2816,4 +2816,3 @@ print(json.dumps(report, indent=2, ensure_ascii=False))
 [1] Anthropic. Effective Context Engineering for AI Agents. `https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents`
 
 [2] David Kim. Context-Engineering (GitHub). `https://github.com/davidkimai/Context-Engineering`
-


### PR DESCRIPTION
## Summary

- align the Chapter 9 `ContextBuilder` examples with the pinned `hello-agents==0.2.8` API
- replace the unsupported `custom_packets` keyword with `additional_packets`
- keep the Chinese and English chapters synchronized across the GSSC explanation and runnable examples

Refs #545

## Root cause

Chapter 9 pins `hello-agents[all]==0.2.8`, whose `ContextBuilder.build()` and internal `_gather()` methods accept `additional_packets`. The chapter instead used `custom_packets` in both languages, so the documented example fails before entering `build()`:

```text
TypeError: ContextBuilder.build() got an unexpected keyword argument 'custom_packets'
```

The mismatch is platform-independent and is also present in the explanatory `_gather()` snippet.

## Verification

### Red/green documentation guard

Before the change, the guard found 8 legacy references in each chapter and failed:

```text
{'docs/chapter9/第九章 上下文工程.md': 8,
 'docs/chapter9/Chapter9-Context-Engineering.md': 8}
AssertionError: legacy keyword remains
```

After the change:

```text
legacy: 0 per chapter
additional_packets: 8 per chapter
```

### Real package contract

Installed the exact pinned wheel in an isolated target directory:

```bash
python3 -m pip install --break-system-packages --ignore-installed \
  --no-deps --target /tmp/ha-target 'hello-agents==0.2.8'
```

Runtime probe result:

```text
version= 0.2.8
signature= (self, user_query: str, conversation_history=..., system_instructions=..., additional_packets=...) -> str
legacy rejected= ContextBuilder.build() got an unexpected keyword argument 'custom_packets'
additional accepted= True
```

Additional checks:

```bash
git diff --check
```

The installed wheel source was also parsed with `ast`: both `build` and `_gather` contain `additional_packets` and neither contains `custom_packets`.

## Competition audit

- Issue #545 timeline: no linked PR, commit, assignee, or cross-reference
- open and closed PR searches for `custom_packets`, `ContextBuilder.build`, and `#545`: no matches
- repository history: the mismatch originated with the Chapter 9 content and remains on current `main`

## Risk

Low. This is a documentation-only identifier correction in two synchronized files. It does not change framework code or dependency versions.

## AI assistance disclosure

AI assistance was used to search the repository, compare the documentation with the pinned wheel, prepare the minimal edit, and run the listed checks. I reviewed the final diff and verification output.
