### PR TITLE
docs: clarify GRPO generation batch constraint

### DIFF
--- a/docs/chapter11/Chapter11-Agentic-RL.md
+++ b/docs/chapter11/Chapter11-Agentic-RL.md
@@ -208,7 +208,7 @@ grpo_result_str = rl_tool.run({
     "output_dir": "./models/quick_test_grpo",
     "max_samples": 5,       # Only use 5 samples for quick test
     "num_epochs": 1,
-    "batch_size": 2,        # Must be divisible by num_generations(8), use 2
+    "batch_size": 2,        # With 4 accumulation steps, the generation batch is 2 × processes × 4, divisible by 8
     "use_lora": True
 })
 

--- a/docs/chapter11/第十一章 Agentic-RL.md
+++ b/docs/chapter11/第十一章 Agentic-RL.md
@@ -208,7 +208,7 @@ grpo_result_str = rl_tool.run({
     "output_dir": "./models/quick_test_grpo",
     "max_samples": 5,       # 只用5个样本快速测试
     "num_epochs": 1,
-    "batch_size": 2,        # 必须能被num_generations(8)整除,使用2
+    "batch_size": 2,        # 默认累积4步时，生成批次为2 × 进程数 × 4，可被默认的8整除
     "use_lora": True
 })
 


### PR DESCRIPTION
## Summary

- clarify that TRL validates the generation batch, not `batch_size` alone
- keep the Chinese and English Chapter 11 examples aligned

## Root cause

The existing comments say that `batch_size=2` must be divisible by the default
`num_generations=8`, which reverses the actual relationship.

In `hello-agents==0.2.5`, `batch_size` is passed to
`per_device_train_batch_size`, while `TrainingConfig` defaults
`gradient_accumulation_steps` to 4. TRL computes the default generation batch
as:

```text
per_device_train_batch_size × num_processes × gradient_accumulation_steps
```

Therefore this example uses `2 × num_processes × 4`, which is divisible by the
default `num_generations=8`.

Refs #862

## Validation

- reproduced the old inverted assertion in both Chapter 11 documents
- checked the published `hello-agents==0.2.5` wheel and its `V0.2.5` source tag
- checked the generation-batch formula and divisibility guard in both the
  minimum supported `trl==0.24.0` and currently resolved `trl==1.12.0`
- ran a local contract check before and after the edit: failed on the old text,
  then passed after the bilingual correction
- `python3 -m py_compile code/chapter11/00_quick_test.py`
- `git diff --check`

This is a documentation-only correction. I did not run GPU training or download
model weights.

## AI assistance

AI assistance was used for repository search and drafting. The dependency
contracts, source paths, diff, and validation results were checked locally.
